### PR TITLE
Give the documentation github action a name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 on: [push]
+name: docs
 
 jobs:
   generate_documentation:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Build status
 
 [![Build status](https://ci.appveyor.com/api/projects/status/yhdf39xo0d8a8nyo/branch/master?svg=true)](https://ci.appveyor.com/project/laudrup/boost-wintls/branch/master)
 [![codecov](https://codecov.io/gh/laudrup/boost-wintls/branch/master/graph/badge.svg)](https://codecov.io/gh/laudrup/boost-wintls)
-[![Documentation](https://img.shields.io/travis/com/laudrup/boost-wintls.svg?label=docs)](https://travis-ci.com/laudrup/boost-wintls)
+[![Documentation](https://github.com/laudrup/boost-wintls/workflows/docs/badge.svg)](https://laudrup.github.io/boost-wintls/)
 
 Documentation
 -------------


### PR DESCRIPTION
Name the github action for generating the documentation so we can
refer to it by name and add a nice badge to the README file.