### PR TITLE
Use CMAKE_CXX_COMPILER CMake variable to find Clang compiler

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,25 +1,42 @@
 version: 1.0.{build}
 
-image:
-  - Visual Studio 2019
+environment:
+  matrix:
+    - compiler: clang
+      cmake_options: -G Ninja -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_CXX_COMPILER=clang-cl
+
+    - compiler: msvc
 
 install:
   - cinst OpenCppCoverage
   - cinst codecov
+  - cinst ninja
   - refreshenv
+
+image:
+  - Visual Studio 2019
 
 configuration:
   - Debug
   - Release
 
 before_build:
-  - cmake -H. -B./build -DBOOST_ROOT="C:/Libraries/boost_1_73_0"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - mkdir build && cd build
+  - cmake %CMAKE_OPTIONS% -DBOOST_ROOT="C:/Libraries/boost_1_73_0" "%APPVEYOR_BUILD_FOLDER%"
 
 build:
   project: build/boost-wintls.sln
 
+for:
+  -
+    matrix:
+      only:
+        - compiler: clang
+    build_script:
+      - ninja
+
 test_script:
-  - cd build
   - ctest -C %CONFIGURATION% --output-on-failure
 
 after_test:


### PR DESCRIPTION
Since the appveyor image doesn't seem to have the LLVM toolset install
with the Visual Studio 2019 image, but does have LLVM installed, use
the CMake variable for specifying the C++ compiler to find Clang.

The requires calling the Visual Studio batch file for setting the
correct paths to toolsets etc.