### PR TITLE
Split documentation sections into seperate pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
       run: sudo apt-get -yq install doxygen libboost-dev libssl-dev python3-pip
     - name: Install PIP packages
       # TODO: Consider using requirements.txt to ensure specific versions are used
-      run: sudo pip3 install sphinx breathe
+      run: sudo pip3 install sphinx breathe sphinxcontrib-fulltoc
     - name: Configure build system
       run: mkdir build && cmake -Bbuild -H.
     - name: Build documentation

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -40,7 +40,12 @@ add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
 		${SPHINX_SOURCE} ${SPHINX_BUILD}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS
-		${CMAKE_CURRENT_SOURCE_DIR}/index.rst
+	  ${CMAKE_CURRENT_SOURCE_DIR}/index.rst
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples.rst
+    ${CMAKE_CURRENT_SOURCE_DIR}/classes.rst
+    ${CMAKE_CURRENT_SOURCE_DIR}/enumerations.rst
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions.rst
+    ${CMAKE_CURRENT_SOURCE_DIR}/type_aliases.rst
     ${CMAKE_CURRENT_SOURCE_DIR}/templates/localtoc.html
     ${CMAKE_CURRENT_SOURCE_DIR}/static/boost-wintls.css
 		${DOXYGEN_INDEX_FILE}

--- a/doc/classes.rst
+++ b/doc/classes.rst
@@ -1,0 +1,12 @@
+Classes
+=======
+
+context
+-------
+.. doxygenclass:: boost::wintls::context
+   :members:
+
+stream
+------
+.. doxygenclass:: boost::wintls::stream
+   :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,13 @@ author = 'Kasper Laudrup'
 
 master_doc = 'index'
 
-extensions = ['breathe']
+rst_prolog = """
+.. figure:: logo.jpg
+   :alt: Boost.Wintls logo
+
+"""
+
+extensions = ['breathe', 'sphinxcontrib.fulltoc']
 
 highlight_language = 'c++'
 

--- a/doc/enumerations.rst
+++ b/doc/enumerations.rst
@@ -1,0 +1,10 @@
+Enumerations
+============
+
+handshake_type
+--------------
+.. doxygenenum:: boost::wintls::handshake_type
+
+method
+------
+.. doxygenenum:: boost::wintls::method

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,0 +1,14 @@
+Examples
+========
+
+Full code to the examples can be found in the `examples`_ directory.
+
+HTTPS Client
+------------
+This example demonstrates a basic synchronous HTTPS client using
+boost::beast.
+
+.. literalinclude:: ../examples/https_client.cpp
+   :lines: 9-
+
+.. _examples: https://github.com/laudrup/boost-wintls/tree/master/examples

--- a/doc/functions.rst
+++ b/doc/functions.rst
@@ -1,0 +1,9 @@
+Functions
+=========
+
+x509_to_cert_context
+--------------------
+.. doxygenfunction:: boost::wintls::x509_to_cert_context(const net::const_buffer &x509, file_format format)
+.. doxygenfunction:: boost::wintls::x509_to_cert_context(const net::const_buffer &x509, file_format format, boost::system::error_code& ec)
+
+.. _CERT_CONTEXT: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,12 @@
-.. figure:: logo.jpg
-   :alt: Boost.Wintls logo
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   examples
+   classes
+   enumerations
+   functions
+   type_aliases
 
 Overview
 ========
@@ -11,58 +18,4 @@ Motivation
 Avoid dependency on OpenSSL on Windows as well as being able to use
 certificates and keys from the Windows certificate stores directly.
 
-Examples
-========
-
-Full code to the examples can be found in the `examples`_ directory.
-
-HTTPS Client
-------------
-This example demonstrates a basic synchronous HTTPS client using
-boost::beast.
-
-.. literalinclude:: ../examples/https_client.cpp
-   :lines: 9-
-
-Classes
-=======
-
-context
--------
-.. doxygenclass:: boost::wintls::context
-   :members:
-
-stream
-------
-.. doxygenclass:: boost::wintls::stream
-   :members:
-
-Enumerations
-============
-
-handshake_type
---------------
-.. doxygenenum:: boost::wintls::handshake_type
-
-method
-------
-.. doxygenenum:: boost::wintls::method
-
-Functions
-=========
-
-x509_to_cert_context
---------------------
-.. doxygenfunction:: boost::wintls::x509_to_cert_context(const net::const_buffer &x509, file_format format)
-.. doxygenfunction:: boost::wintls::x509_to_cert_context(const net::const_buffer &x509, file_format format, boost::system::error_code& ec)
-
-Type aliases
-============
-
-cert_context_ptr
-----------------
-.. doxygentypedef:: boost::wintls::cert_context_ptr
-
 .. _SSPI/Schannel: https://docs.microsoft.com/en-us/windows-server/security/tls/tls-ssl-schannel-ssp-overview/
-.. _examples: https://github.com/laudrup/boost-wintls/tree/master/examples
-.. _CERT_CONTEXT: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context

--- a/doc/type_aliases.rst
+++ b/doc/type_aliases.rst
@@ -1,0 +1,8 @@
+Type aliases
+============
+
+cert_context_ptr
+----------------
+.. doxygentypedef:: boost::wintls::cert_context_ptr
+
+.. _CERT_CONTEXT: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_context


### PR DESCRIPTION
Instead of having one huge file with the documentation including
examples and what is generated from the sources, split it into
separate sections to improve navigation a bit.

This also means using the fulltoc extension to expand the section
currently being viewed.

This is not exactly how I want it, but still better than it was.