### PR TITLE
Cleanup CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,25 +6,16 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 option(ENABLE_TESTING "Enable Test Builds" ON)
 option(ENABLE_EXAMPLES "Enable Examples Builds" ON)
-option(ENABLE_DOCUMENTATION "Enable Documentation Builds" ON)
+option(ENABLE_DOCUMENTATION "Enable Documentation Builds" OFF)
 
-if (WIN32)
+if(WIN32)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_MULTITHREADED ON)
   set(Boost_USE_STATIC_RUNTIME OFF)
+  find_package(Boost REQUIRED)
 
-  # Generate .pdb files with debug info for release builds
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
-endif()
-
-# TODO: We don't need these if we're only generating documentation
-find_package(Boost REQUIRED)
-find_package(OpenSSL COMPONENTS SSL Crypto)
-find_package(Threads)
-
-if (WIN32)
   add_library(boost-wintls INTERFACE)
+
   target_link_libraries(boost-wintls INTERFACE
     Boost::headers
     )
@@ -32,7 +23,7 @@ if (WIN32)
   target_link_libraries(boost-wintls INTERFACE
     Crypt32
     Secur32
-    Rpcrt4
+    Rpcrt4 # TODO: Remove when we no longer use uuid
     )
 
   # Target Windows 7
@@ -73,6 +64,14 @@ if (WIN32)
   target_include_directories(boost-wintls INTERFACE include)
   target_compile_options(boost-wintls INTERFACE ${MSVC_WARNINGS})
   target_compile_definitions(boost-wintls INTERFACE _CRT_SECURE_NO_WARNINGS)
+
+  # Generate .pdb files with debug info for release builds
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
+else()
+  set(ENABLE_TESTING OFF)
+  set(ENABLE_EXAMPLES OFF)
+  set(ENABLE_DOCUMENTATION ON)
 endif()
 
 if(ENABLE_TESTING)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,31 +1,14 @@
 add_executable(https_client https_client.cpp)
 
-if (WIN32)
-  target_link_libraries(https_client PRIVATE
-    boost-wintls
-    )
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Temporary workaround issue https://github.com/boostorg/beast/issues/1582
-    target_compile_options(https_client PRIVATE "$<$<CONFIG:RELEASE>:-wd4702>")
-  endif()
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(https_client PRIVATE -Wno-unused-private-field)
-  endif()
-else()
-  if (NOT OPENSSL_FOUND)
-    message(SEND_ERROR "OpenSSL not found. Cannot build examples.")
-    return()
-  endif()
+target_link_libraries(https_client PRIVATE
+  boost-wintls
+)
 
-  if (NOT Threads_FOUND)
-    message(SEND_ERROR "Threads library not found. Cannot build examples.")
-    return()
-  endif()
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Temporary workaround issue https://github.com/boostorg/beast/issues/1582
+  target_compile_options(https_client PRIVATE "$<$<CONFIG:RELEASE>:-wd4702>")
+endif()
 
-  target_link_libraries(https_client PRIVATE
-    Boost::headers
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    Threads::Threads
-    )
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(https_client PRIVATE -Wno-unused-private-field)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,14 @@
 Include(FetchContent)
 
-if (NOT OPENSSL_FOUND)
+find_package(OpenSSL COMPONENTS SSL Crypto)
+find_package(Threads)
+
+if(NOT OPENSSL_FOUND)
   message(SEND_ERROR "OpenSSL not found. Cannot build tests.")
   return()
 endif()
 
-if (NOT Threads_FOUND)
+if(NOT Threads_FOUND)
   message(SEND_ERROR "Threads library not found. Cannot build tests.")
   return()
 endif()
@@ -34,33 +37,26 @@ set(test_sources
   main.cpp
   echo_test.cpp
   tls_record.cpp
+  error_test.cpp
+  handshake_test.cpp
+  certificate_test.cpp
   )
-
-if (WIN32)
-  list(APPEND test_sources
-    error_test.cpp
-    handshake_test.cpp
-    certificate_test.cpp
-    )
-endif()
 
 add_executable(unittest
   ${test_sources}
   )
 
-if (WIN32)
-  add_custom_command(OUTPUT "$ENV{userprofile}/.rnd"
-    COMMAND openssl rand -out "$ENV{userprofile}/.rnd"
-    VERBATIM
-    )
+add_custom_command(OUTPUT "$ENV{userprofile}/.rnd"
+  COMMAND openssl rand -out "$ENV{userprofile}/.rnd"
+  VERBATIM
+)
 
-  add_custom_target(
-    generate-random
-    DEPENDS "$ENV{userprofile}/.rnd"
-    )
+add_custom_target(
+  generate-random
+  DEPENDS "$ENV{userprofile}/.rnd"
+  )
 
-  add_dependencies(generate-certificate generate-random)
-endif()
+add_dependencies(generate-certificate generate-random)
 
 add_dependencies(unittest generate-certificate)
 
@@ -74,13 +70,8 @@ target_link_libraries(unittest PRIVATE
   OpenSSL::Crypto
   Threads::Threads
   Catch2::Catch2
+  boost-wintls
   )
-
-if (WIN32)
-  target_link_libraries(unittest PRIVATE
-    boost-wintls
-    )
-endif()
 
 include(CTest)
 include(Catch)

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -8,9 +8,7 @@
 #include "async_echo_server.hpp"
 #include "async_echo_client.hpp"
 
-#ifdef _WIN32
 #include <boost/wintls.hpp>
-#endif
 
 #include <catch2/catch.hpp>
 
@@ -89,7 +87,6 @@ struct asio_ssl_server_stream {
   asio_ssl::stream<test_stream&> stream;
 };
 
-#ifdef _WIN32
 struct wintls_client_context : public boost::wintls::context {
   wintls_client_context()
     : boost::wintls::context(boost::wintls::method::system_default) {
@@ -134,17 +131,11 @@ struct wintls_server_stream {
   test_stream tst;
   boost::wintls::stream<test_stream&> stream;
 };
-#endif
 
-#ifdef _WIN32
 using TestTypes = std::tuple<std::tuple<asio_ssl_client_stream, asio_ssl_server_stream>,
                              std::tuple<wintls_client_stream, asio_ssl_server_stream>,
                              std::tuple<asio_ssl_client_stream, wintls_server_stream>,
                              std::tuple<wintls_client_stream, wintls_server_stream>>;
-#else
-using TestTypes = std::tuple<std::tuple<asio_ssl_client_stream, asio_ssl_server_stream>>;
-#endif
-
 
 TEMPLATE_LIST_TEST_CASE("echo test", "", TestTypes) {
   using Client = typename std::tuple_element<0, TestType>::type;


### PR DESCRIPTION
It doesn't really seem to make much sense to attempt to build any of
the code on other platforms than Windows. At least for now. So cleanup
the CMake files so only the documentation is generated on sane
platforms and the code is built on Windows. This also means removing a
few ugly #ifdefs.