### PR TITLE
Use underscore postfix for private members

### DIFF
--- a/include/boost/wintls/context.hpp
+++ b/include/boost/wintls/context.hpp
@@ -34,9 +34,9 @@ public:
    * @param connection_method The @ref method to use for connections.
    */
   explicit context(method connection_method)
-    : m_impl(std::make_unique<detail::context_impl>())
-    , m_method(connection_method)
-    , m_verify_server_certificate(false) {
+    : impl_(std::make_unique<detail::context_impl>())
+    , method_(connection_method)
+    , verify_server_certificate_(false) {
   }
 
   /** Add certification authority for performing verification.
@@ -49,7 +49,7 @@ public:
    * @throws boost::system::system_error Thrown on failure.
    */
   void add_certificate_authority(const CERT_CONTEXT* cert) {
-    m_impl->add_certificate_authority(cert);
+    impl_->add_certificate_authority(cert);
   }
 
   /** Add certification authority for performing verification.
@@ -63,7 +63,7 @@ public:
    */
   void add_certificate_authority(const CERT_CONTEXT* cert, boost::system::error_code& ec) {
     try {
-      m_impl->add_certificate_authority(cert);
+      impl_->add_certificate_authority(cert);
     } catch (const boost::system::system_error& e) {
       ec = e.code();
     }
@@ -79,82 +79,82 @@ public:
    * verified
    */
   void verify_server_certificate(bool verify) {
-    m_verify_server_certificate = verify;
+    verify_server_certificate_ = verify;
   }
 
   void set_default_verify_paths() {
-    m_impl->use_default_cert_store = true;
+    impl_->use_default_cert_store = true;
   }
 
   void set_default_verify_paths(boost::system::error_code& ec) {
-    m_impl->use_default_cert_store = true;
+    impl_->use_default_cert_store = true;
     ec = {};
   }
 
   void use_certificate(const net::const_buffer& certificate, file_format format, boost::system::error_code& ec) {
     try {
-      m_impl->use_certificate(certificate, format);
+      impl_->use_certificate(certificate, format);
     } catch (const boost::system::system_error& e) {
       ec = e.code();
     }
   }
 
   void use_certificate(const net::const_buffer& certificate, file_format format) {
-    m_impl->use_certificate(certificate, format);
+    impl_->use_certificate(certificate, format);
   }
 
   void use_certificate_file(const std::string& filename, file_format format, boost::system::error_code& ec) {
     try {
-      m_impl->use_certificate_file(filename, format);
+      impl_->use_certificate_file(filename, format);
     } catch (const boost::system::system_error& e) {
       ec = e.code();
     }
   }
 
   void use_certificate_file(const std::string& filename, file_format format) {
-    m_impl->use_certificate_file(filename, format);
+    impl_->use_certificate_file(filename, format);
   }
 
   void use_private_key(const net::const_buffer& private_key, file_format format, boost::system::error_code& ec) {
     try {
-      m_impl->use_private_key(private_key, format);
+      impl_->use_private_key(private_key, format);
     } catch (const boost::system::system_error& e) {
       ec = e.code();
     }
   }
 
   void use_private_key(const net::const_buffer& private_key, file_format format) {
-    m_impl->use_private_key(private_key, format);
+    impl_->use_private_key(private_key, format);
   }
 
   void use_private_key_file(const std::string& filename, file_format format, boost::system::error_code& ec) {
     try {
-      m_impl->use_private_key_file(filename, format);
+      impl_->use_private_key_file(filename, format);
     } catch (const boost::system::system_error& e) {
       ec = e.code();
     }
   }
 
   void use_private_key_file(const std::string& filename, file_format format) {
-    m_impl->use_private_key_file(filename, format);
+    impl_->use_private_key_file(filename, format);
   }
 
 private:
   boost::winapi::DWORD_ verify_certificate(const CERT_CONTEXT* cert) {
-    if (!m_verify_server_certificate) {
+    if (!verify_server_certificate_) {
       return boost::winapi::ERROR_SUCCESS_;
     }
-    return m_impl->verify_certificate(cert);
+    return impl_->verify_certificate(cert);
   }
 
   const CERT_CONTEXT* server_cert() const {
-    return m_impl->server_cert.get();
+    return impl_->server_cert.get();
   }
 
   friend class detail::sspi_handshake;
-  std::unique_ptr<detail::context_impl> m_impl;
-  method m_method;
-  bool m_verify_server_certificate;
+  std::unique_ptr<detail::context_impl> impl_;
+  method method_;
+  bool verify_server_certificate_;
 };
 
 } // namespace wintls

--- a/include/boost/wintls/detail/context_impl.hpp
+++ b/include/boost/wintls/detail/context_impl.hpp
@@ -27,18 +27,18 @@ namespace detail {
 struct context_impl {
 
   context_impl()
-    : m_cert_store(CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, 0, nullptr)) {
-    if (m_cert_store == nullptr) {
+    : cert_store_(CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, 0, nullptr)) {
+    if (cert_store_ == nullptr) {
       throw_last_error("CertOpenStore");
     }
   }
 
   ~context_impl() {
-    CertCloseStore(m_cert_store, 0);
+    CertCloseStore(cert_store_, 0);
   }
 
   void add_certificate_authority(const CERT_CONTEXT* cert) {
-    if(!CertAddCertificateContextToStore(m_cert_store,
+    if(!CertAddCertificateContextToStore(cert_store_,
                                          cert,
                                          CERT_STORE_ADD_ALWAYS,
                                          nullptr)) {
@@ -51,7 +51,7 @@ struct context_impl {
     // certificates have been added to the in memory store by the user
     CERT_CHAIN_ENGINE_CONFIG chain_engine_config{};
     chain_engine_config.cbSize = sizeof(chain_engine_config);
-    chain_engine_config.hExclusiveRoot = m_cert_store;
+    chain_engine_config.hExclusiveRoot = cert_store_;
 
     struct cert_chain_engine {
       ~cert_chain_engine() {
@@ -176,7 +176,7 @@ private:
     return policy_status.dwError;
   }
 
-  HCERTSTORE m_cert_store;
+  HCERTSTORE cert_store_;
 };
 
 } // namespace detail


### PR DESCRIPTION
Instead of prefixing private member variables with m_ postfix them
with an underscore.

That seems to be what is most common for boost libraries and what I
prefer anyway so no idea why I did otherwise.