### PR TITLE
Add codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1.0%
+      patch: off
+
+comment:
+  require_changes: true


### PR DESCRIPTION
Only fail builds/PRs if code coverage drops more than 1%.

Hopefully adding a configuration for this is all that is needed.