### PR TITLE
Don't regenerate test certificate

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,22 +13,11 @@ if(NOT Threads_FOUND)
   return()
 endif()
 
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/test_server.key ${CMAKE_CURRENT_BINARY_DIR}/test_server.cert
-  COMMAND openssl req -nodes -new -x509  -keyout test_server.key -out test_server.cert -subj "/C=DK/L=Copenhagen/O=Reptilicus/CN=localhost"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  VERBATIM
-  )
-
-add_custom_target(
-  generate-certificate
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test_server.key ${CMAKE_CURRENT_BINARY_DIR}/test_server.cert
-  )
-
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v2.13.6)
+  GIT_TAG        v2.13.6
+)
 
 FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
@@ -43,36 +32,16 @@ set(test_sources
   sspi_buffer_sequence_test.cpp
   stream_test.cpp
   decrypted_data_buffer_test.cpp
-  )
+)
 
 add_executable(unittest
   ${test_sources}
-  )
+)
 
 if(ENABLE_ADDRESS_SANITIZER)
   # Workaround for: https://github.com/catchorg/Catch2/issues/898
   target_compile_definitions(unittest PRIVATE CATCH_CONFIG_NO_WINDOWS_SEH)
 endif()
-
-add_custom_command(OUTPUT "$ENV{userprofile}/.rnd"
-  COMMAND openssl rand -out "$ENV{userprofile}/.rnd"
-  VERBATIM
-)
-
-add_custom_target(
-  generate-random
-  DEPENDS "$ENV{userprofile}/.rnd"
-  )
-
-add_dependencies(generate-certificate generate-random)
-
-add_dependencies(unittest generate-certificate)
-
-target_compile_definitions(unittest PRIVATE
-  TEST_CERTIFICATE_PATH="${CMAKE_CURRENT_BINARY_DIR}/test_server.cert"
-  TEST_PRIVATE_KEY_PATH="${CMAKE_CURRENT_BINARY_DIR}/test_server.key"
-  TEST_PRIVATE_KEY_NAME="${PROJECT_NAME}-test-key"
-)
 
 target_link_libraries(unittest PRIVATE
   OpenSSL::SSL
@@ -80,7 +49,7 @@ target_link_libraries(unittest PRIVATE
   Threads::Threads
   Catch2::Catch2
   boost-wintls
-  )
+)
 
 include(CTest)
 include(Catch)

--- a/test/asio_ssl_client_stream.hpp
+++ b/test/asio_ssl_client_stream.hpp
@@ -8,11 +8,12 @@
 #define ASIO_SSL_CLIENT_STREAM_HPP
 
 #include "unittest.hpp"
+#include "certificate.hpp"
 
 struct asio_ssl_client_context : public asio_ssl::context {
   asio_ssl_client_context()
     : asio_ssl::context(asio_ssl::context_base::tls) {
-    load_verify_file(TEST_CERTIFICATE_PATH);
+    add_certificate_authority(net::buffer(test_certificate));
   }
 };
 

--- a/test/asio_ssl_server_stream.hpp
+++ b/test/asio_ssl_server_stream.hpp
@@ -7,13 +7,14 @@
 #ifndef ASIO_SSL_SERVER_STREAM_HPP
 #define ASIO_SSL_SERVER_STREAM_HPP
 
+#include "certificate.hpp"
 #include "unittest.hpp"
 
 struct asio_ssl_server_context : public asio_ssl::context {
   asio_ssl_server_context()
     : asio_ssl::context(asio_ssl::context_base::tls) {
-    use_certificate_file(TEST_CERTIFICATE_PATH, asio_ssl::context_base::pem);
-    use_private_key_file(TEST_PRIVATE_KEY_PATH, asio_ssl::context_base::pem);
+    use_certificate(net::buffer(test_certificate), asio_ssl::context_base::pem);
+    use_private_key(net::buffer(test_key), asio_ssl::context_base::pem);
   }
 };
 

--- a/test/certificate.hpp
+++ b/test/certificate.hpp
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2022 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef WINTLS_CERTIFICATE_HPP
+#define WINTLS_CERTIFICATE_HPP
+
+#include <string>
+
+const std::string test_certificate =
+  "-----BEGIN CERTIFICATE-----\n"
+  "MIIDbzCCAlegAwIBAgIUaIFyQGvp8/q1J7Lun753bvRBjKQwDQYJKoZIhvcNAQEL\n"
+  "BQAwRzELMAkGA1UEBhMCREsxEzARBgNVBAcMCkNvcGVuaGFnZW4xDzANBgNVBAoM\n"
+  "BldpblRMUzESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTIyMDYyNTIwMzg0OVoXDTQ5\n"
+  "MTExMDIwMzg0OVowRzELMAkGA1UEBhMCREsxEzARBgNVBAcMCkNvcGVuaGFnZW4x\n"
+  "DzANBgNVBAoMBldpblRMUzESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG\n"
+  "9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy6b79MKE2mdt1h7GtfFmol68HI/Q3tOsPHaJ\n"
+  "cDv7PfflJofqlae1SPFAs4OspQ7IAjcwuictiyE9MbPo5vgiAEctZ2aP2PbF99AP\n"
+  "XAtkeLLLF5zxqVTbQtmEt147aycALe7WddVNQqlAFQ7gd6VCo/1jZMRlwNHPT1Oi\n"
+  "PkowAfVpDYCIwuL/0Rc6bRkh8p6J5Oi6S4sWcT7e6oo81NOKwyK6h2WJ8c01tFWp\n"
+  "G26XySopaH3u2HT+3Elg0lIdaaAm4EhZMysYIsPli+o2OiM4Dm2qGwK/VxeZz83W\n"
+  "aFS8jYPZQkB2fWOAk3Lm/hLLkSj5Z0qcin4543DOREO3b9J4ZQIDAQABo1MwUTAd\n"
+  "BgNVHQ4EFgQU8TcsJp8OfaZJvBIfCOz5fqnhztwwHwYDVR0jBBgwFoAU8TcsJp8O\n"
+  "faZJvBIfCOz5fqnhztwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC\n"
+  "AQEAsUryE+jjeg/8xhwvthH+GJVjQSVvAbJjd1PQMLo3Yy578a1UN6aBOELwRe4W\n"
+  "FgR3ASRKhrc/mnSju0eLSF69lSWStjJC+ZNlZRuwOS/Ik9A6BAe6sOARpKPV1rV2\n"
+  "uWs8PxsWqPuTdICri91bEpmq1jntNTRgXmFW/hQR2ndy03h9hUHd0Xn70mlESayJ\n"
+  "2s6qnAMp+OzlTtWO6eSYYajYQdmsmIpby5eGjPzPNhoIVPKtSUa6eN5GltlW74qu\n"
+  "75w4XWlNO3J0AX4ZoWc7fztsWkgTX41Vv48lkxPLqLxQQTQsN6wdZ/c/sdSAXK0x\n"
+  "GinlCF73ogVSHXdtNMGrQP1n8w==\n"
+  "-----END CERTIFICATE-----\n";
+
+const std::string test_key =
+  "-----BEGIN PRIVATE KEY-----\n"
+  "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDLpvv0woTaZ23W\n"
+  "Hsa18WaiXrwcj9De06w8dolwO/s99+Umh+qVp7VI8UCzg6ylDsgCNzC6Jy2LIT0x\n"
+  "s+jm+CIARy1nZo/Y9sX30A9cC2R4sssXnPGpVNtC2YS3XjtrJwAt7tZ11U1CqUAV\n"
+  "DuB3pUKj/WNkxGXA0c9PU6I+SjAB9WkNgIjC4v/RFzptGSHynonk6LpLixZxPt7q\n"
+  "ijzU04rDIrqHZYnxzTW0VakbbpfJKilofe7YdP7cSWDSUh1poCbgSFkzKxgiw+WL\n"
+  "6jY6IzgObaobAr9XF5nPzdZoVLyNg9lCQHZ9Y4CTcub+EsuRKPlnSpyKfjnjcM5E\n"
+  "Q7dv0nhlAgMBAAECggEBAKRhZa/7rsang5W4g8ZqUuCuvQIE56BklPq851TrZXFw\n"
+  "fctrG+OuWfrFmOcNWrZkRvba2372jqFltAJBaLW+BZvZ2AFFXMjQ75yGmU8/dtqh\n"
+  "3qJxsPJwJwc/kgt8iVOFSHTK+tpj0JgFC0+0EWUhxLefmLHGgSdxcvdh12yV70g0\n"
+  "APtKnCax/QznmW1XbXiEqP9n5mspOeC2LcJLKdH6PRiCeN+AnYAI5tzMm0L5Z8KS\n"
+  "JepiCYc/Saxdd3FkIus+VSaqKPBF3XcwfIglkZe5AzOTpQQZuSOEvKasvf2Lm+bT\n"
+  "ZgWCujDmg5Fdrjake4jZRQE2ZZirFJMc6wu4XCSnwqECgYEA5PoqcmfYs14/Mf3Z\n"
+  "XDSeAKqsOB61NA/A0ylvaCJixzRUylt8IgTJ9XJ0qiPOFCEcKr3DOlehZXLCieCO\n"
+  "XeHDOHRSfRn4clMAQOs3EgOWRCF1IjdS99FismwPAToY3kbrCfvqN/h+cqd1lJSL\n"
+  "NhboOMOPZmH1mJ29h9ukqMac4j0CgYEA46+0V6b+fd/AbfX6oLnOQcS3cyJKyPC6\n"
+  "nljzjbsx123+zgAlhqStE3wL3PjzJMepS0H4h2w4owobfOcrGhpxVbWTdQRSUqpX\n"
+  "X04Q+9YjDWg7OsPTQYXN1e/NCbw25WH8jPhtrZcaHwAtqPVsh94WCmKREiXg4VrU\n"
+  "5MZ6z4zWGUkCgYAeBrgePIPsMYWz9ofUUYoOqFLhIRW99/rfNeXIEApH+RLNXmXO\n"
+  "yDX7m8C0tvFFLnpVGIFLW0Zs2TmtfubsZLiG5KoUgZ1U0JGN8cpM8G96C7EihYK5\n"
+  "wJlisEzfalDshPw5WPGD2XArdM40Z65Br4tQNkTNtjbQho7eC+1xvGnCOQKBgCzw\n"
+  "NfEC5cHkUq+hWAk3Aw2aDPctcoM8eCjet5tmsgyqChuQjdeIUxzAY/sGK787pR9U\n"
+  "cwAPjRIo4YoCelBZnbrj7qmu46yrMDmAR/vcpOh1hRMxKVYKWbj67oYYXuFhOJ5+\n"
+  "Pe+AHki2GUz6u6QJYmJEWAuz7DGuYsyQnBaw3mT5AoGBAK83Z0rszmsS2F2xM0J3\n"
+  "3xtHxaXmvJdDQto29M2+CT0vYvTBZGPT8BOPuRzkWJzDSpoSduqZNnsrh1idWL5Q\n"
+  "IVNc0eS7mhAa/9QZkkU9JyyTfbzCEvchZkMD6uyFhS9zaDFUrBQjDcx0SXeoUP9i\n"
+  "hOHwm+u6yzjHKIsf0M/ATOru\n"
+  "-----END PRIVATE KEY-----\n";
+
+const std::string test_key_name="boost-wintls-test-key";
+#endif

--- a/test/certificate_test.cpp
+++ b/test/certificate_test.cpp
@@ -5,6 +5,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include "certificate.hpp"
 #include "unittest.hpp"
 
 #include <boost/wintls/certificate.hpp>
@@ -40,8 +41,7 @@ bool container_exists(const std::string& name) {
 
 TEST_CASE("certificate conversion") {
   SECTION("valid cert bytes") {
-    const auto cert_bytes = test_cert_bytes();
-    const auto cert = boost::wintls::x509_to_cert_context(net::buffer(cert_bytes), boost::wintls::file_format::pem);
+    const auto cert = boost::wintls::x509_to_cert_context(net::buffer(test_certificate), boost::wintls::file_format::pem);
     CHECK(get_cert_name(cert.get()) == "localhost");
   }
 
@@ -59,11 +59,11 @@ TEST_CASE("import private key") {
   const std::string name{"boost::wintls crypto test container"};
   REQUIRE_FALSE(container_exists(name));
 
-  boost::wintls::import_private_key(net::buffer(test_key_bytes()), boost::wintls::file_format::pem, name);
+  boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, name);
   CHECK(container_exists(name));
 
   boost::system::error_code ec;
-  boost::wintls::import_private_key(net::buffer(test_key_bytes()), boost::wintls::file_format::pem, name, ec);
+  boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, name, ec);
   CHECK(ec.value() == NTE_EXISTS);
 
   boost::wintls::delete_private_key(name);

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -5,8 +5,9 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include "async_echo_server.hpp"
 #include "async_echo_client.hpp"
+#include "async_echo_server.hpp"
+#include "certificate.hpp"
 #include "tls_record.hpp"
 #include "unittest.hpp"
 
@@ -23,8 +24,8 @@ TEST_CASE("certificates") {
   boost::wintls::context client_ctx(boost::wintls::method::system_default);
 
   boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
-  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
-  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
+  server_ctx.use_certificate_chain(net::buffer(test_certificate));
+  server_ctx.use_private_key(net::buffer(test_key), boost::asio::ssl::context::pem);
 
   net::io_context io_context;
   boost::wintls::stream<test_stream> client_stream(io_context, client_ctx);
@@ -107,8 +108,7 @@ TEST_CASE("certificates") {
 
     client_ctx.verify_server_certificate(true);
 
-    const auto x509 = test_cert_bytes();
-    const auto cert_ptr = x509_to_cert_context(net::buffer(x509), boost::wintls::file_format::pem);
+    const auto cert_ptr = x509_to_cert_context(net::buffer(test_certificate), boost::wintls::file_format::pem);
     client_ctx.add_certificate_authority(cert_ptr.get());
 
     auto client_error = errc::make_error_code(errc::not_supported);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,8 +1,10 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
 
-#include <boost/wintls/certificate.hpp>
+#include "certificate.hpp"
 #include "unittest.hpp"
+
+#include <boost/wintls/certificate.hpp>
 
 #include <cstdlib>
 #include <iostream>
@@ -10,8 +12,8 @@
 int main(int argc, char* argv[]) {
   boost::system::error_code ec;
 
-  boost::wintls::delete_private_key(TEST_PRIVATE_KEY_NAME, ec);
-  boost::wintls::import_private_key(net::buffer(test_key_bytes()), boost::wintls::file_format::pem, TEST_PRIVATE_KEY_NAME, ec);
+  boost::wintls::delete_private_key(test_key_name, ec);
+  boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, test_key_name, ec);
   if (ec) {
     std::cerr << "Unable to import private test key: " << ec.message() << "\n";
     return EXIT_FAILURE;
@@ -19,7 +21,7 @@ int main(int argc, char* argv[]) {
 
   int result = Catch::Session().run(argc, argv);
 
-  boost::wintls::delete_private_key(TEST_PRIVATE_KEY_NAME, ec);
+  boost::wintls::delete_private_key(test_key_name, ec);
     if (ec) {
     std::cerr << "Unable to delete private test key: " << ec.message() << "\n";
     return EXIT_FAILURE;

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -29,16 +29,6 @@ struct StringMaker<boost::system::error_code> {
 };
 }
 
-inline std::vector<char> test_cert_bytes() {
-  std::ifstream ifs{TEST_CERTIFICATE_PATH};
-  return {std::istreambuf_iterator<char>{ifs}, {}};
-}
-
-inline std::vector<char> test_key_bytes() {
-  std::ifstream ifs{TEST_PRIVATE_KEY_PATH};
-  return {std::istreambuf_iterator<char>{ifs}, {}};
-}
-
 namespace net = boost::wintls::net;
 namespace asio_ssl = boost::asio::ssl;
 using test_stream = boost::beast::test::stream;

--- a/test/wintls_client_stream.hpp
+++ b/test/wintls_client_stream.hpp
@@ -7,6 +7,7 @@
 #ifndef WINTLS_CLIENT_STREAM_HPP
 #define WINTLS_CLIENT_STREAM_HPP
 
+#include "certificate.hpp"
 #include "unittest.hpp"
 
 #include <boost/wintls.hpp>
@@ -17,8 +18,7 @@
 struct wintls_client_context : public boost::wintls::context {
   wintls_client_context()
     : boost::wintls::context(boost::wintls::method::system_default) {
-    const auto x509 = test_cert_bytes();
-    const auto cert_ptr = x509_to_cert_context(net::buffer(x509), boost::wintls::file_format::pem);
+    const auto cert_ptr = x509_to_cert_context(net::buffer(test_certificate), boost::wintls::file_format::pem);
     add_certificate_authority(cert_ptr.get());
   }
 };

--- a/test/wintls_server_stream.hpp
+++ b/test/wintls_server_stream.hpp
@@ -8,14 +8,15 @@
 #define WINTLS_SERVER_STREAM_HPP
 
 #include "unittest.hpp"
+#include "certificate.hpp"
 
 #include <boost/wintls.hpp>
 
 struct wintls_server_context : public boost::wintls::context {
   wintls_server_context()
     : boost::wintls::context(boost::wintls::method::system_default) {
-    auto certificate = boost::wintls::x509_to_cert_context(net::buffer(test_cert_bytes()), boost::wintls::file_format::pem);
-    boost::wintls::assign_private_key(certificate.get(), TEST_PRIVATE_KEY_NAME);
+    auto certificate = boost::wintls::x509_to_cert_context(net::buffer(test_certificate), boost::wintls::file_format::pem);
+    boost::wintls::assign_private_key(certificate.get(), test_key_name);
     use_certificate(certificate.get());
   }
 };


### PR DESCRIPTION
Instead of having a custom target for generating a test certificate
and key just do it once and add the resulting PEM string to a header
for use in tests.

This simplifies things a bit.