### PR TITLE
Pass Hostname to Certificate Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 __pycache__
-build
+/out/build
+
+# Visual Studio Code generated files
 .vscode
+
+# Visual Studio generated files
+/.vs
+/CMakeSettings.json

--- a/include/boost/wintls/certificate.hpp
+++ b/include/boost/wintls/certificate.hpp
@@ -218,7 +218,7 @@ inline void delete_private_key(const std::string& name, boost::system::error_cod
  * existing or non accessible key will result in unexpected behavior
  * when used with a @ref stream operating as a server.
  *
- * @param cert The certifcate to associate with the private key.
+ * @param cert The certificate to associate with the private key.
  *
  * @param name The name of the private key in the default cryptographic key provider.
  *

--- a/include/boost/wintls/context.hpp
+++ b/include/boost/wintls/context.hpp
@@ -13,6 +13,8 @@
 #include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/context_certificates.hpp>
 
+#include <string>
+
 namespace boost {
 namespace wintls {
 
@@ -111,11 +113,11 @@ public:
   }
 
 private:
-  DWORD verify_certificate(const CERT_CONTEXT* cert) {
+  DWORD verify_certificate(const CERT_CONTEXT* cert, const std::string& server_hostname) {
     if (!verify_server_certificate_) {
       return ERROR_SUCCESS;
     }
-    return static_cast<DWORD>(ctx_certs_.verify_certificate(cert));
+    return static_cast<DWORD>(ctx_certs_.verify_certificate(cert, server_hostname));
   }
 
   const CERT_CONTEXT* server_cert() const {

--- a/include/boost/wintls/detail/sspi_handshake.hpp
+++ b/include/boost/wintls/detail/sspi_handshake.hpp
@@ -276,7 +276,7 @@ private:
 
     cert_context_ptr remote_cert{ctx_ptr, &CertFreeCertificateContext};
 
-    last_error_ = static_cast<SECURITY_STATUS>(context_.verify_certificate(remote_cert.get()));
+    last_error_ = static_cast<SECURITY_STATUS>(context_.verify_certificate(remote_cert.get(), server_hostname_));
     if (last_error_ != SEC_E_OK) {
       return last_error_;
     }


### PR DESCRIPTION
Introduce verification of host names as mentioned in 1) in #56 

I suppose using the hostname set in set_server_hostname for this is fine? The [documentation](https://wintls.dev/classes.html#_CPPv4N5boost6wintls6stream19set_server_hostnameERKNSt6stringE) already states that this is also used for certificate verification.

The necessary conversion to wstring is unfortunate, but i do not see a better way to do this..?

Ideally there would be a test case for this and possibly more cases in certificate_test.cpp, i guess.
Just taking certificates from badssl.com would be a simple approach. But they will expire at some point and would have to be renewed which depends on the continued avilability of that site.