### PR TITLE
Use US English locale for unittest thread

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build with cov-build
       shell: bash
       run: |
-        cov-analysis-win64-2020.09/bin/cov-build --dir cov-int cmake --build build/
+        cov-analysis-win64-2021.12.1/bin/cov-build --dir cov-int cmake --build build/
         7z a boost-wintls.zip cov-int
     - name: Upload to coverity-scan
       shell: bash

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -10,8 +10,11 @@
 #include <iostream>
 
 int main(int argc, char* argv[]) {
-  boost::system::error_code ec;
+  // Ensure the test are using US English locale. Some tests depend on
+  // comparing potentially localized message strings.
+  SetThreadUILanguage(MAKELCID(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), SORT_DEFAULT));
 
+  boost::system::error_code ec;
   boost::wintls::delete_private_key(test_key_name, ec);
   boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, test_key_name, ec);
   if (ec) {


### PR DESCRIPTION
Some of the test cases (at least the error message test) compares
error message strings which could potentially be localized.

These tests will fail if running in another locale than English so
ensure we run all the tests with a US English locale at least in the
main thread.

Fixes #59 