### PR TITLE
Fix coverity github action

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   coverity-scan:
-    runs-on: windows-latest
+    runs-on: windows-2019
     name: Build with coverity and upload to coverity scan
     steps:
     - name: Checkout
@@ -35,6 +35,9 @@ jobs:
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       shell: bash
       run: cmake -B build -DENABLE_DOCUMENTATION=OFF
+    - name: Configure Coverity
+      shell: bash
+      run: cov-analysis-win64-2021.12.1/bin/cov-configure --msvc
     - name: Build with cov-build
       shell: bash
       run: |


### PR DESCRIPTION
Coverity needs to run cov-configure before being able to run cov-build
after the upgrade to a newer version of coverity so add a step to the
github action for doing that.