### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 Language: Cpp
-BasedOnStyle: None
 AlignAfterOpenBracket: Align
 AlignEscapedNewlines: Left
 AlignOperands: Align
@@ -30,11 +29,15 @@ EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: true
 IncludeBlocks: Regroup
+IndentCaseLabels: true
 IndentWidth: 2
 LambdaBodyIndentation: Signature
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 PackConstructorInitializers: Never
+PenaltyBreakAssignment: 100
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left
@@ -49,7 +52,7 @@ SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: Always
+SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
While working on #63, clang-format did not work for me without any helpful error message.
(Besides three Options that are not yet available in Clang 13 which i am using, but i can remove these locally, that is fine.)
I just figured out that removing the line `BasedOnStyle: None` solves the problem for me. Also, according to the clang format documentation the value None does not seem to exist for that option.

After getting it to work, i have also made some more changes to align the settings a bit more with the existing code.