### PR TITLE
Do not delete Move Operations of Stream

### DIFF
--- a/include/boost/wintls/stream.hpp
+++ b/include/boost/wintls/stream.hpp
@@ -61,9 +61,6 @@ public:
     , sspi_stream_(std::make_unique<detail::sspi_stream>(ctx)) {
   }
 
-  stream(stream&& other) = default;
-  stream& operator=(stream&& other) = delete;
-
   /** Get the executor associated with the object.
    *
    * This function may be used to obtain the executor object that the


### PR DESCRIPTION
Stream has one unique_ptr member which is not problematic and one member of template type NextLayer. Removing the explicit deletion makes this class moveable if and only if NextLayer is.

Note that only move assignment was deleted, while move construction was defaulted.