### PR TITLE
Do not delete Move Operations of Context

### DIFF
--- a/include/boost/wintls/context.hpp
+++ b/include/boost/wintls/context.hpp
@@ -33,9 +33,6 @@ public:
     , verify_server_certificate_(false) {
   }
 
-  context(context&&) = delete;
-  context& operator=(context&&) = delete;
-
   /** Add certification authority for performing verification.
    *
    * This function is used to add one trusted certification authority


### PR DESCRIPTION
context Members are bool, enum, detail::context_certificates detail::context_certificates has a bool and two unique_ptr. Move operations are not problematic for any of these.

This does, for example, allow user code to have a factory functions to set up a context in a certain way and return it.