### PR TITLE
add shutdown test cases

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(test_sources
   sspi_buffer_sequence_test.cpp
   stream_test.cpp
   decrypted_data_buffer_test.cpp
+  shutdown_test.cpp
 )
 
 add_executable(unittest

--- a/test/shutdown_test.cpp
+++ b/test/shutdown_test.cpp
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2020 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "echo_server.hpp"
+#include "echo_client.hpp"
+#include "async_echo_server.hpp"
+#include "async_echo_client.hpp"
+#include "asio_ssl_client_stream.hpp"
+#include "asio_ssl_server_stream.hpp"
+#include "wintls_client_stream.hpp"
+#include "wintls_server_stream.hpp"
+#include "unittest.hpp"
+
+#include <boost/wintls.hpp>
+
+
+TEST_CASE("Asio.SSL shutdown test") {
+  SECTION("stream truncated - client closes after server shutdown") {
+    net::io_context io_context;
+    echo_server<asio_ssl_server_stream> server(io_context);
+    echo_client<asio_ssl_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    auto shutdown_result = server.shutdown();
+    client.stream.lowest_layer().close();
+    CHECK(shutdown_result.get() == asio_ssl::error::stream_truncated);
+  }
+
+  SECTION("stream truncated  - client closes before server shutdown") {
+    net::io_context io_context;
+    echo_server<asio_ssl_server_stream> server(io_context);
+    echo_client<asio_ssl_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    client.stream.lowest_layer().close();
+    auto shutdown_result = server.shutdown();
+    CHECK(shutdown_result.get() == asio_ssl::error::stream_truncated);
+  }
+
+  SECTION("okay") {
+    net::io_context io_context;
+    echo_server<asio_ssl_server_stream> server(io_context);
+    echo_client<asio_ssl_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    auto shutdown_result = server.shutdown();
+    client.shutdown();
+    // according to https://stackoverflow.com/a/25703699/16814536 this should produce asio::error::eof
+    // is that information outdated?
+    CHECK_FALSE(shutdown_result.get());
+  }
+}
+
+TEST_CASE("WinTLS shutdown test") {
+  SECTION("stream truncated - client closes after server shutdown") {
+    net::io_context io_context;
+    echo_server<wintls_server_stream> server(io_context);
+    echo_client<wintls_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    auto shutdown_result = server.shutdown();
+    client.stream.next_layer().close();
+    // #TODO: this documents the current behavior, that is likely wrong
+    CHECK_FALSE(shutdown_result.get());
+  }
+
+  SECTION("stream truncated  - client closes before server shutdown") {
+    net::io_context io_context;
+    echo_server<wintls_server_stream> server(io_context);
+    echo_client<wintls_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    client.stream.next_layer().close();
+    auto shutdown_result = server.shutdown();
+    // #TODO: this documents the current behavior, that is likely wrong
+    CHECK_FALSE(shutdown_result.get());
+  }
+
+  SECTION("okay") {
+    net::io_context io_context;
+    echo_server<wintls_server_stream> server(io_context);
+    echo_client<wintls_client_stream> client(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    auto shutdown_result = server.shutdown();
+    client.shutdown();
+    CHECK_FALSE(shutdown_result.get());
+  }
+}


### PR DESCRIPTION
This should not be merged in the current state but is rather supposed to show of a difference between Asio.SSL and WinTLS: Asio will produce a stream_truncated error on shutdown, if the remote did not properly shut down the protocol while WinTLS will not.

Note https://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error

Also, according to that post, Asio should produce an error if it initiated the shutdown and it goes through without problem.
This does not seem to be the case (anymore?).
This is relevant for the https examples in WinTLS. Currently the https async example handles asio::error::eof (as do the beast examples async+sync), while the sync example does not.