### PR TITLE
Remove functional include and use unique_ptr more efficiently

### DIFF
--- a/include/boost/wintls/detail/context_certificates.hpp
+++ b/include/boost/wintls/detail/context_certificates.hpp
@@ -14,7 +14,6 @@
 #include <boost/wintls/error.hpp>
 
 #include <cstdlib>
-#include <functional>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -23,7 +22,7 @@ namespace boost {
 namespace wintls {
 namespace detail {
 
-using cert_store_ptr = std::unique_ptr<std::remove_pointer_t<HCERTSTORE>, std::function<void(HCERTSTORE)>>;
+using cert_store_ptr = std::unique_ptr<std::remove_pointer_t<HCERTSTORE>, void(*)(HCERTSTORE)>;
 
 class context_certificates {
 public:
@@ -167,7 +166,7 @@ private:
     return policy_status.dwError;
   }
 
-  cert_store_ptr cert_store_;
+  cert_store_ptr cert_store_{nullptr, [](HCERTSTORE){}};
   cert_context_ptr server_cert_{nullptr, &CertFreeCertificateContext};
 };
 

--- a/include/boost/wintls/detail/sspi_handshake.hpp
+++ b/include/boost/wintls/detail/sspi_handshake.hpp
@@ -285,7 +285,7 @@ private:
       return last_error_;
     }
 
-    cert_context_ptr remote_cert{ctx_ptr, &CertFreeCertificateContext};
+    cert_context_ptr remote_cert{ctx_ptr};
 
     last_error_ = static_cast<SECURITY_STATUS>(context_.verify_certificate(remote_cert.get(), server_hostname_, check_revocation_));
     if (last_error_ != SEC_E_OK) {

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -124,7 +124,7 @@ boost::wintls::cert_context_ptr create_self_signed_cert(const std::string& subje
   if (!cert) {
     boost::wintls::detail::throw_last_error("CertCreateSelfSignCertificate");
   }
-  return boost::wintls::cert_context_ptr{cert, &CertFreeCertificateContext};
+  return boost::wintls::cert_context_ptr{cert};
 }
 
 std::string cert_container_name(const CERT_CONTEXT* cert) {

--- a/test/wintls_client_stream.hpp
+++ b/test/wintls_client_stream.hpp
@@ -15,17 +15,13 @@
 #include <fstream>
 #include <iterator>
 
-inline boost::wintls::cert_context_ptr make_empty_cert_context_ptr() {
-  return boost::wintls::cert_context_ptr{nullptr, &CertFreeCertificateContext};
-}
-
 const std::string test_key_name_client = test_key_name + "-client";
 
 struct wintls_client_context : public boost::wintls::context {
   wintls_client_context()
     : boost::wintls::context(boost::wintls::method::system_default)
     , needs_private_key_clean_up_(false)
-    , authority_ptr_(make_empty_cert_context_ptr()) {
+    , authority_ptr_() {
   }
 
   void with_test_cert_authority() {


### PR DESCRIPTION
A technicality i came across while looking through the code.
If a unique_ptr type is always used with the same deleter function, it should be part of the deleter type instead of using function pointers or even std::function.
This has the advantage, that we do not have to repeat the deleter function for every instantiation and it is also a little more efficient, as not every unique_ptr has to save the additional function pointer or function object within it. (sizeof(cert_context_ptr) is now 8 and was 16 before.)