### PR TITLE
Refactor handshake

### DIFF
--- a/include/boost/wintls/detail/async_handshake.hpp
+++ b/include/boost/wintls/detail/async_handshake.hpp
@@ -82,29 +82,6 @@ struct async_handshake : boost::asio::coroutine {
           self.complete(handshake_.last_error());
           return;
         }
-
-        if (handshake_state == detail::sspi_handshake::state::done_with_data) {
-          BOOST_ASIO_CORO_YIELD {
-            state_ = state::writing;
-            net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
-          }
-          break;
-        }
-
-        if (handshake_state == detail::sspi_handshake::state::error_with_data) {
-          BOOST_ASIO_CORO_YIELD {
-            state_ = state::writing;
-            net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
-          }
-          if (!is_continuation()) {
-            BOOST_ASIO_CORO_YIELD {
-              auto e = self.get_executor();
-              net::post(e, [self = std::move(self), ec, length]() mutable { self(ec, length); });
-            }
-          }
-          self.complete(handshake_.last_error());
-          return;
-        }
       }
 
       if (!is_continuation()) {
@@ -114,6 +91,7 @@ struct async_handshake : boost::asio::coroutine {
         }
       }
       BOOST_ASSERT(!handshake_.last_error());
+      handshake_.manual_auth();
       self.complete(handshake_.last_error());
     }
   }

--- a/include/boost/wintls/detail/async_handshake.hpp
+++ b/include/boost/wintls/detail/async_handshake.hpp
@@ -12,23 +12,21 @@
 
 #include <boost/wintls/detail/sspi_handshake.hpp>
 
-#include <boost/asio/coroutine.hpp>
-
 namespace boost {
 namespace wintls {
 namespace detail {
 
-template <typename NextLayer>
-struct async_handshake : boost::asio::coroutine {
+template<typename NextLayer>
+struct async_handshake {
   async_handshake(NextLayer& next_layer, detail::sspi_handshake& handshake, handshake_type type)
-    : next_layer_(next_layer)
-    , handshake_(handshake)
-    , entry_count_(0)
-    , state_(state::idle) {
+      : next_layer_(next_layer)
+      , handshake_(handshake)
+      , entry_count_(0)
+      , state_(state::idle) {
     handshake_(type);
   }
 
-  template <typename Self>
+  template<typename Self>
   void operator()(Self& self, boost::system::error_code ec = {}, std::size_t length = 0) {
     if (ec) {
       self.complete(ec);
@@ -40,7 +38,7 @@ struct async_handshake : boost::asio::coroutine {
       return entry_count_ > 1;
     };
 
-    switch(state_) {
+    switch (state_) {
       case state::reading:
         handshake_.size_read(length);
         state_ = state::idle;
@@ -53,45 +51,33 @@ struct async_handshake : boost::asio::coroutine {
         break;
     }
 
-    detail::sspi_handshake::state handshake_state;
-    BOOST_ASIO_CORO_REENTER(*this) {
-      while((handshake_state = handshake_()) != detail::sspi_handshake::state::done) {
-        if (handshake_state == detail::sspi_handshake::state::data_needed) {
-          BOOST_ASIO_CORO_YIELD {
-            state_ = state::reading;
-            next_layer_.async_read_some(handshake_.in_buffer(), std::move(self));
-          }
-          continue;
-        }
-
-        if (handshake_state == detail::sspi_handshake::state::data_available) {
-          BOOST_ASIO_CORO_YIELD {
-            state_ = state::writing;
-            net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
-          }
-          continue;
-        }
-
-        if (handshake_state == detail::sspi_handshake::state::error) {
-          if (!is_continuation()) {
-            BOOST_ASIO_CORO_YIELD {
-              auto e = self.get_executor();
-              net::post(e, [self = std::move(self), ec, length]() mutable { self(ec, length); });
-            }
-          }
-          self.complete(handshake_.last_error());
-          return;
-        }
+    switch ((handshake_())) {
+      case detail::sspi_handshake::state::data_needed: {
+        state_ = state::reading;
+        next_layer_.async_read_some(handshake_.in_buffer(), std::move(self));
+        return;
       }
-
-      if (!is_continuation()) {
-        BOOST_ASIO_CORO_YIELD {
-          auto e = self.get_executor();
-          net::post(e, [self = std::move(self), ec, length]() mutable { self(ec, length); });
-        }
+      case detail::sspi_handshake::state::data_available: {
+        state_ = state::writing;
+        net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
+        return;
       }
-      BOOST_ASSERT(!handshake_.last_error());
-      handshake_.manual_auth();
+      case detail::sspi_handshake::state::error: {
+        break;
+      }
+      case detail::sspi_handshake::state::done: {
+        BOOST_ASSERT(!handshake_.last_error());
+        handshake_.manual_auth();
+        break;
+      }
+    }
+    // If this is the first call to this function, it would cause the completion handler
+    // (invoked by self.complete()) to be executed on the wrong executor.
+    // Ensure that doesn't happen by posting the completion handler instead of calling it directly.
+    if (!is_continuation()) {
+      auto e = self.get_executor();
+      net::post(e, [self = std::move(self), ec, length]() mutable { self(ec, length); });
+    } else {
       self.complete(handshake_.last_error());
     }
   }

--- a/include/boost/wintls/detail/async_handshake.hpp
+++ b/include/boost/wintls/detail/async_handshake.hpp
@@ -100,7 +100,6 @@ private:
   NextLayer& next_layer_;
   detail::sspi_handshake& handshake_;
   int entry_count_;
-  std::vector<char> input_;
   enum class state {
     idle,
     reading,

--- a/include/boost/wintls/detail/sspi_handshake.hpp
+++ b/include/boost/wintls/detail/sspi_handshake.hpp
@@ -28,15 +28,11 @@ namespace detail {
 
 class sspi_handshake {
 public:
-  // TODO: enhancement: done_with_data and error_with_data can be removed if
-  // we move the manual validate logic out of the handshake loop.
   enum class state {
-    data_needed,      // data needs to be read from peer
-    data_available,   // data needs to be write to peer
-    done_with_data,   // handshake success, but there is leftover data to be written to peer
-    error_with_data,  // handshake error, but there is leftover data to be written to peer
-    done,             // handshake success
-    error             // handshake error
+    data_needed,           // data needs to be read from peer
+    data_available,        // data needs to be write to peer
+    done,                  // handshake success
+    error                  // handshake error
   };
 
   sspi_handshake(context& context, ctxt_handle& ctxt_handle, cred_handle& cred_handle)
@@ -129,6 +125,9 @@ public:
   }
 
   state operator()() {
+    if (last_error_ == SEC_E_OK) {
+      return state::done;
+    }
     if (last_error_ != SEC_I_CONTINUE_NEEDED && last_error_ != SEC_E_INCOMPLETE_MESSAGE) {
       return state::error;
     }
@@ -209,13 +208,9 @@ public:
         return has_buffer_output ? state::data_available : state::data_needed;
       }
       case SEC_E_OK: {
-        // sspi handshake ok. perform manual auth here.
-        manual_auth();
-        if (handshake_type_ == handshake_type::client) {
-          if (last_error_ != SEC_E_OK) {
-            return state::error;
-          }
-        } else {
+        // sspi handshake ok. Manual authentication will be done after the handshake loop.
+
+        if (handshake_type_ == handshake_type::server) {
           // Note: we are not checking (out_flags & ASC_RET_MUTUAL_AUTH) is true,
           // but instead rely on our manual cert validation to establish trust.
           // "The AcceptSecurityContext function will return ASC_RET_MUTUAL_AUTH if a
@@ -227,7 +222,7 @@ public:
           // "If function generated an output token, the token must be sent to the client process."
           // This happens when client cert is requested.
           if (has_buffer_output) {
-            return last_error_ == SEC_E_OK ? state::done_with_data : state::error_with_data;
+            return state::data_available;
           }
         }
         return state::done;
@@ -274,7 +269,6 @@ public:
     check_revocation_ = check;
   }
 
-private:
   SECURITY_STATUS manual_auth(){
     if (!context_.verify_server_certificate_) {
       return SEC_E_OK;
@@ -284,16 +278,12 @@ private:
     if (last_error_ != SEC_E_OK) {
       return last_error_;
     }
-
     cert_context_ptr remote_cert{ctx_ptr};
-
     last_error_ = static_cast<SECURITY_STATUS>(context_.verify_certificate(remote_cert.get(), server_hostname_, check_revocation_));
-    if (last_error_ != SEC_E_OK) {
-      return last_error_;
-    }
     return last_error_;
   }
 
+private:
   context& context_;
   ctxt_handle& ctxt_handle_;
   cred_handle& cred_handle_;

--- a/include/boost/wintls/detail/sspi_handshake.hpp
+++ b/include/boost/wintls/detail/sspi_handshake.hpp
@@ -69,16 +69,11 @@ public:
       BOOST_UNREACHABLE_RETURN(0);
     }();
 
-    auto server_cert = context_.server_cert();
-    if (handshake_type_ == handshake_type::server && server_cert != nullptr) {
-      creds.cCreds = 1;
-      creds.paCred = &server_cert;
-    }
-
     // TODO: rename server_cert field since it is also used for client cert.
     // Note: if client cert is set, sspi will auto validate server cert with it.
     // Even though verify_server_certificate_ in context is set to false.
-    if (handshake_type_ == handshake_type::client && server_cert != nullptr) {
+    auto server_cert = context_.server_cert();
+    if (server_cert != nullptr) {
       creds.cCreds = 1;
       creds.paCred = &server_cert;
     }

--- a/include/boost/wintls/stream.hpp
+++ b/include/boost/wintls/stream.hpp
@@ -137,9 +137,8 @@ public:
   void handshake(handshake_type type, boost::system::error_code& ec) {
     sspi_stream_->handshake(type);
 
-    detail::sspi_handshake::state state;
-    while((state = sspi_stream_->handshake()) != detail::sspi_handshake::state::done) {
-      switch (state) {
+    while (true) {
+      switch (sspi_stream_->handshake()) {
         case detail::sspi_handshake::state::data_needed: {
           std::size_t size_read = next_layer_.read_some(sspi_stream_->handshake.in_buffer(), ec);
           if (ec) {
@@ -159,24 +158,11 @@ public:
         case detail::sspi_handshake::state::error:
           ec = sspi_stream_->handshake.last_error();
           return;
-        case detail::sspi_handshake::state::done_with_data:{
-          std::size_t size_written = net::write(next_layer_, sspi_stream_->handshake.out_buffer(), ec);
-          if (ec) {
-            return;
-          }
-          sspi_stream_->handshake.size_written(size_written);
-          return;
-        }
-        case detail::sspi_handshake::state::error_with_data:{
-          std::size_t size_written = net::write(next_layer_, sspi_stream_->handshake.out_buffer(), ec);
-          if (ec) {
-            return;
-          }
-          sspi_stream_->handshake.size_written(size_written);
-          return;
-        }
         case detail::sspi_handshake::state::done:
-          BOOST_UNREACHABLE_RETURN(0);
+          if (sspi_stream_->handshake.manual_auth() != SEC_E_OK) {
+            ec = sspi_stream_->handshake.last_error();
+          }
+          return;
       }
     }
   }


### PR DESCRIPTION
This is intended to simplify the handshake code.
It should simplify reusing much of the handshake code in order to resolve #75 in a future PR.

I also changed a few small things i came across while working on this. All should be documented within the commit messages.
I hope i did not miss any subtleties why async_handshake was a coroutine? I could not think of a good reason with the current code.

Feedback would be much appreciated :)