### PR TITLE
Add support for standalone Asio

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -119,7 +119,7 @@ jobs:
         disk-root: "C:"
 
     - name: Install packages
-      run: choco install openssl
+      run: choco install openssl --version 3.1.1
 
     - name: Create build directory
       run: mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+include(FetchContent)
 include(VersionFromGit)
 
 version_from_git()
@@ -19,6 +20,7 @@ elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
   message(STATUS "Building for 32 bit platform")
 endif()
 
+option(ENABLE_WINTLS_STANDALONE_ASIO "Enable Standalone WINTLS" OFF)
 option(ENABLE_TESTING "Enable Test Builds" ${WIN32})
 option(ENABLE_EXAMPLES "Enable Examples Builds" ${WIN32})
 option(ENABLE_DOCUMENTATION "Enable Documentation Builds" ${UNIX})
@@ -27,11 +29,35 @@ option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
+if(ENABLE_WINTLS_STANDALONE_ASIO)
+  FetchContent_Declare(
+    asio
+    GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+    GIT_TAG        asio-1-28-0
+  )
+
+  FetchContent_GetProperties(asio)
+  if(NOT asio_POPULATED)
+    FetchContent_Populate(asio)
+  endif()
+endif()
+
 target_include_directories(${PROJECT_NAME}
   INTERFACE
   $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+if(ENABLE_WINTLS_STANDALONE_ASIO)
+  target_include_directories(${PROJECT_NAME}
+    INTERFACE
+    ${asio_SOURCE_DIR}/asio/include
+  )
+  target_compile_definitions(${PROJECT_NAME}
+    INTERFACE
+    WINTLS_USE_STANDALONE_ASIO
+  )
+endif()
 
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_14)
 
@@ -119,11 +145,13 @@ if(WIN32)
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
 endif()
 
-find_package(Boost REQUIRED)
+if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
+  find_package(Boost REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} INTERFACE
-  Boost::headers
-)
+  target_link_libraries(${PROJECT_NAME} INTERFACE
+    Boost::headers
+  )
+endif()
 
 if(MINGW)
   target_link_libraries(${PROJECT_NAME} INTERFACE

--- a/include/boost/wintls/certificate.hpp
+++ b/include/boost/wintls/certificate.hpp
@@ -11,18 +11,11 @@
 #include <boost/wintls/error.hpp>
 #include <boost/wintls/file_format.hpp>
 
-
 #include <boost/wintls/detail/config.hpp>
+#include <boost/wintls/detail/assert.hpp>
 #include <boost/wintls/detail/win32_crypto.hpp>
 
 #include <memory>
-#include <cassert>
-
-#if defined(NDEBUG)
-#define WINTLS_VERIFY_MSG(expr, msg) ((void)(expr))
-#else
-#define WINTLS_VERIFY_MSG(expr, msg) assert((expr) && (msg))
-#endif
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/context.hpp
+++ b/include/boost/wintls/context.hpp
@@ -40,7 +40,7 @@ public:
    *
    * @param cert The certficate to add to the certificate store
    *
-   * @throws boost::system::system_error Thrown on failure.
+   * @throws wintls::system_error Thrown on failure.
    */
   void add_certificate_authority(const CERT_CONTEXT* cert) {
     ctx_certs_.add_certificate_authority(cert);
@@ -55,10 +55,10 @@ public:
    *
    * @param ec Set to indicate what error occurred, if any.
    */
-  void add_certificate_authority(const CERT_CONTEXT* cert, boost::system::error_code& ec) {
+  void add_certificate_authority(const CERT_CONTEXT* cert, wintls::error_code& ec) {
     try {
       ctx_certs_.add_certificate_authority(cert);
-    } catch (const boost::system::system_error& e) {
+    } catch (const wintls::system_error& e) {
       ec = e.code();
     }
   }
@@ -106,7 +106,7 @@ public:
    * is imported from a public certificate @ref assign_private_key can
    * be used for that.
    *
-   * @throws boost::system::system_error Thrown on failure.
+   * @throws wintls::system_error Thrown on failure.
    */
   void use_certificate(const CERT_CONTEXT* cert) {
     ctx_certs_.use_certificate(cert);
@@ -127,10 +127,10 @@ public:
    *
    * @param ec Set to indicate what error occurred, if any.
    */
-  void use_certificate(const CERT_CONTEXT* cert, boost::system::error_code& ec) {
+  void use_certificate(const CERT_CONTEXT* cert, wintls::error_code& ec) {
     try {
       ctx_certs_.use_certificate(cert);
-    } catch (const boost::system::system_error& e) {
+    } catch (const wintls::system_error& e) {
       ec = e.code();
     }
   }

--- a/include/boost/wintls/detail/assert.hpp
+++ b/include/boost/wintls/detail/assert.hpp
@@ -1,0 +1,36 @@
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_DETAIL_ASSERT_HPP
+#define BOOST_WINTLS_DETAIL_ASSERT_HPP
+
+#include <cassert>
+
+#if defined(NDEBUG)
+#define WINTLS_ASSERT_MSG(expr, msg) ((void)(expr))
+#else
+#define WINTLS_ASSERT_MSG(expr, msg) assert((expr) && (msg))
+#endif
+
+#if defined(NDEBUG)
+#define WINTLS_VERIFY_MSG(expr, msg) ((void)(expr))
+#else
+#define WINTLS_VERIFY_MSG(expr, msg) assert((expr) && (msg))
+#endif
+
+#if defined(__clang__)
+#define WINTLS_UNREACHABLE_RETURN(x) __builtin_unreachable();
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define WINTLS_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if BOOST_GCC_VERSION >= 40500
+#define WINTLS_UNREACHABLE_RETURN(x) __builtin_unreachable();
+#else
+#define WINTLS_UNREACHABLE_RETURN(x) ;
+#endif
+#elif defined(_MSC_VER)
+#define WINTLS_UNREACHABLE_RETURN(x) __assume(0);
+#endif
+
+#endif

--- a/include/boost/wintls/detail/async_handshake.hpp
+++ b/include/boost/wintls/detail/async_handshake.hpp
@@ -11,13 +11,8 @@
 #include <boost/wintls/handshake_type.hpp>
 
 #include <boost/wintls/detail/config.hpp>
+#include <boost/wintls/detail/coroutine.hpp>
 #include <boost/wintls/detail/sspi_handshake.hpp>
-
-#ifdef WINTLS_USE_STANDALONE_ASIO
-#include <asio/coroutine.hpp>
-#else
-#include <boost/asio/coroutine.hpp>
-#endif
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/detail/async_read.hpp
+++ b/include/boost/wintls/detail/async_read.hpp
@@ -9,13 +9,8 @@
 #define BOOST_WINTLS_DETAIL_ASYNC_READ_HPP
 
 #include <boost/wintls/detail/config.hpp>
+#include <boost/wintls/detail/coroutine.hpp>
 #include <boost/wintls/detail/sspi_decrypt.hpp>
-
-#ifdef WINTLS_USE_STANDALONE_ASIO
-#include <asio/coroutine.hpp>
-#else
-#include <boost/asio/coroutine.hpp>
-#endif
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/detail/async_shutdown.hpp
+++ b/include/boost/wintls/detail/async_shutdown.hpp
@@ -9,13 +9,8 @@
 #define BOOST_WINTLS_DETAIL_ASYNC_SHUTDOWN_HPP
 
 #include <boost/wintls/detail/config.hpp>
+#include <boost/wintls/detail/coroutine.hpp>
 #include <boost/wintls/detail/sspi_shutdown.hpp>
-
-#ifdef WINTLS_USE_STANDALONE_ASIO
-#include <asio/coroutine.hpp>
-#else
-#include <boost/asio/coroutine.hpp>
-#endif
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/detail/async_write.hpp
+++ b/include/boost/wintls/detail/async_write.hpp
@@ -9,14 +9,8 @@
 #define BOOST_WINTLS_DETAIL_ASYNC_WRITE_HPP
 
 #include <boost/wintls/detail/config.hpp>
+#include <boost/wintls/detail/coroutine.hpp>
 #include <boost/wintls/detail/sspi_encrypt.hpp>
-
-#ifdef WINTLS_USE_STANDALONE_ASIO
-#include <asio/coroutine.hpp>
-#else
-#include <boost/asio/coroutine.hpp>
-#endif
-
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/detail/config.hpp
+++ b/include/boost/wintls/detail/config.hpp
@@ -8,13 +8,25 @@
 #ifndef BOOST_WINTLS_DETAIL_CONFIG_HPP
 #define BOOST_WINTLS_DETAIL_CONFIG_HPP
 
-#include <boost/config.hpp>
+//#define WINTLS_USE_STANDALONE_ASIO
 
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
+#ifdef WINTLS_USE_STANDALONE_ASIO
+#include <system_error>
+#include <asio.hpp>
+#define WINTLS_ASIO_CORO_YIELD ASIO_CORO_YIELD
+#define WINTLS_ASIO_CORO_REENTER ASIO_CORO_REENTER
+#else
+#include <boost/config.hpp>
+#include <boost/system/system_error.hpp>
+#include <boost/system/error_code.hpp>
 #include <boost/asio.hpp>
+#define WINTLS_ASIO_CORO_YIELD BOOST_ASIO_CORO_YIELD
+#define WINTLS_ASIO_CORO_REENTER BOOST_ASIO_CORO_REENTER
+#endif
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -26,8 +38,19 @@
 
 namespace boost {
 namespace wintls {
+#ifdef WINTLS_USE_STANDALONE_ASIO
+namespace net = asio;
+using system_error = std::system_error;
+using error_code = std::error_code;
 
+constexpr auto system_category = std::system_category;
+#else
 namespace net = boost::asio;
+using system_error = boost::system::system_error;
+using error_code = boost::system::error_code;
+
+constexpr auto system_category = boost::system::system_category;
+#endif
 
 } // namespace wintls
 } // namespace boost

--- a/include/boost/wintls/detail/config.hpp
+++ b/include/boost/wintls/detail/config.hpp
@@ -17,15 +17,11 @@
 #ifdef WINTLS_USE_STANDALONE_ASIO
 #include <system_error>
 #include <asio.hpp>
-#define WINTLS_ASIO_CORO_YIELD ASIO_CORO_YIELD
-#define WINTLS_ASIO_CORO_REENTER ASIO_CORO_REENTER
 #else
 #include <boost/config.hpp>
 #include <boost/system/system_error.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/asio.hpp>
-#define WINTLS_ASIO_CORO_YIELD BOOST_ASIO_CORO_YIELD
-#define WINTLS_ASIO_CORO_REENTER BOOST_ASIO_CORO_REENTER
 #endif
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/include/boost/wintls/detail/coroutine.hpp
+++ b/include/boost/wintls/detail/coroutine.hpp
@@ -1,0 +1,21 @@
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_DETAIL_COROUTINE_HPP
+#define BOOST_WINTLS_DETAIL_COROUTINE_HPP
+
+#include <boost/wintls/detail/config.hpp>
+
+#ifdef WINTLS_USE_STANDALONE_ASIO
+#include <asio/coroutine.hpp>
+#define WINTLS_ASIO_CORO_YIELD ASIO_CORO_YIELD
+#define WINTLS_ASIO_CORO_REENTER ASIO_CORO_REENTER
+#else
+#include <boost/asio/coroutine.hpp>
+#define WINTLS_ASIO_CORO_YIELD BOOST_ASIO_CORO_YIELD
+#define WINTLS_ASIO_CORO_REENTER BOOST_ASIO_CORO_REENTER
+#endif
+
+#endif

--- a/include/boost/wintls/detail/error.hpp
+++ b/include/boost/wintls/detail/error.hpp
@@ -5,34 +5,33 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#ifndef BOOST_WINTLS_DETAIL_ERROR_HPP
-#define BOOST_WINTLS_DETAIL_ERROR_HPP
+#ifndef WINTLS_DETAIL_ERROR_HPP
+#define WINTLS_DETAIL_ERROR_HPP
 
-#include <boost/system/system_error.hpp>
-#include <boost/system/error_code.hpp>
+#include <boost/wintls/detail/config.hpp>
 
 namespace boost {
 namespace wintls {
 namespace detail {
 
-inline boost::system::error_code get_last_error() noexcept {
-  return boost::system::error_code(static_cast<int>(GetLastError()), boost::system::system_category());
+inline wintls::error_code get_last_error() noexcept {
+  return wintls::error_code(static_cast<int>(GetLastError()), wintls::system_category());
 }
 
 inline void throw_last_error(const char* msg) {
-  throw boost::system::system_error(get_last_error(), msg);
+  throw wintls::system_error(get_last_error(), msg);
 }
 
 inline void throw_last_error() {
-  throw boost::system::system_error(get_last_error());
+  throw wintls::system_error(get_last_error());
 }
 
-inline void throw_error(const boost::system::error_code& ec) {
-  throw boost::system::system_error(ec);
+inline void throw_error(const wintls::error_code& ec) {
+  throw wintls::system_error(ec);
 }
 
-inline void throw_error(const boost::system::error_code& ec, const char* msg) {
-  throw boost::system::system_error(ec, msg);
+inline void throw_error(const wintls::error_code& ec, const char* msg) {
+  throw wintls::system_error(ec, msg);
 }
 
 } // namespace detail

--- a/include/boost/wintls/detail/sspi_buffer_sequence.hpp
+++ b/include/boost/wintls/detail/sspi_buffer_sequence.hpp
@@ -10,7 +10,11 @@
 #include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/sspi_functions.hpp>
 
+#ifdef WINTLS_USE_STANDALONE_ASIO
+#include <asio/buffer.hpp>
+#else
 #include <boost/asio/buffer.hpp>
+#endif
 
 #include <array>
 

--- a/include/boost/wintls/detail/sspi_decrypt.hpp
+++ b/include/boost/wintls/detail/sspi_decrypt.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_WINTLS_DETAIL_SSPI_DECRYPT_HPP
 #define BOOST_WINTLS_DETAIL_SSPI_DECRYPT_HPP
 
+#include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/sspi_functions.hpp>
 #include <boost/wintls/detail/decrypt_buffers.hpp>
 #include <boost/wintls/detail/decrypted_data_buffer.hpp>
@@ -94,7 +95,7 @@ public:
   std::size_t size_decrypted;
   net::mutable_buffer input_buffer;
 
-  boost::system::error_code last_error() const {
+  wintls::error_code last_error() const {
     return error::make_error_code(last_error_);
   }
 

--- a/include/boost/wintls/detail/sspi_encrypt.hpp
+++ b/include/boost/wintls/detail/sspi_encrypt.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_WINTLS_DETAIL_SSPI_ENCRYPT_HPP
 #define BOOST_WINTLS_DETAIL_SSPI_ENCRYPT_HPP
 
+#include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/encrypt_buffers.hpp>
 #include <boost/wintls/detail/sspi_sec_handle.hpp>
 
@@ -23,7 +24,7 @@ public:
   }
 
   template <typename ConstBufferSequence>
-  std::size_t operator()(const ConstBufferSequence& buf, boost::system::error_code& ec) {
+  std::size_t operator()(const ConstBufferSequence& buf, wintls::error_code& ec) {
     SECURITY_STATUS sc = SEC_E_OK;
 
     std::size_t size_encrypted = buffers(buf, sc);

--- a/include/boost/wintls/detail/sspi_functions.hpp
+++ b/include/boost/wintls/detail/sspi_functions.hpp
@@ -10,6 +10,12 @@
 
 #include <boost/wintls/detail/sspi_types.hpp>
 
+#if defined(NDEBUG)
+#define WINTLS_ASSERT_MSG(expr, msg) ((void)(expr))
+#else
+#define WINTLS_ASSERT_MSG(expr, msg) assert((expr) && (msg))
+#endif
+
 namespace boost {
 namespace wintls {
 namespace detail {
@@ -18,7 +24,7 @@ namespace sspi_functions {
 inline SecurityFunctionTable* sspi_function_table() {
   static SecurityFunctionTable* impl = InitSecurityInterface();
   // TODO: Figure out some way to signal this to the user instead of aborting
-  BOOST_ASSERT_MSG(impl != nullptr, "Unable to initialize SecurityFunctionTable");
+  WINTLS_ASSERT_MSG(impl != nullptr, "Unable to initialize SecurityFunctionTable");
   return impl;
 }
 

--- a/include/boost/wintls/detail/sspi_functions.hpp
+++ b/include/boost/wintls/detail/sspi_functions.hpp
@@ -8,13 +8,8 @@
 #ifndef BOOST_WINTLS_DETAIL_SSPI_FUNCTIONS_HPP
 #define BOOST_WINTLS_DETAIL_SSPI_FUNCTIONS_HPP
 
+#include <boost/wintls/detail/assert.hpp>
 #include <boost/wintls/detail/sspi_types.hpp>
-
-#if defined(NDEBUG)
-#define WINTLS_ASSERT_MSG(expr, msg) ((void)(expr))
-#else
-#define WINTLS_ASSERT_MSG(expr, msg) assert((expr) && (msg))
-#endif
 
 namespace boost {
 namespace wintls {

--- a/include/boost/wintls/detail/sspi_handshake.hpp
+++ b/include/boost/wintls/detail/sspi_handshake.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_WINTLS_DETAIL_SSPI_HANDSHAKE_HPP
 #define BOOST_WINTLS_DETAIL_SSPI_HANDSHAKE_HPP
 
+#include <boost/wintls/detail/assert.hpp>
 #include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/sspi_functions.hpp>
 #include <boost/wintls/detail/context_flags.hpp>
@@ -21,12 +22,6 @@
 #include <array>
 #include <memory>
 #include <string>
-
-#if defined(NDEBUG)
-#define WINTLS_ASSERT_MSG(expr, msg) ((void)(expr))
-#else
-#define WINTLS_ASSERT_MSG(expr, msg) assert((expr) && (msg))
-#endif
 
 namespace boost {
 namespace wintls {
@@ -76,7 +71,7 @@ public:
         case handshake_type::server:
           return SECPKG_CRED_INBOUND;
       }
-      std::abort(); // unreachable here
+      WINTLS_UNREACHABLE_RETURN(0);
     }();
 
     auto server_cert = context_.server_cert();

--- a/include/boost/wintls/detail/sspi_shutdown.hpp
+++ b/include/boost/wintls/detail/sspi_shutdown.hpp
@@ -15,7 +15,7 @@
 #include <boost/wintls/detail/sspi_context_buffer.hpp>
 #include <boost/wintls/detail/sspi_sec_handle.hpp>
 
-#include <boost/assert.hpp>
+#include <cassert>
 
 namespace boost {
 namespace wintls {
@@ -28,7 +28,7 @@ public:
     , cred_handle_(cred_handle) {
   }
 
-  boost::system::error_code operator()() {
+  wintls::error_code operator()() {
     shutdown_buffers buffers;
 
     SECURITY_STATUS sc = detail::sspi_functions::ApplyControlToken(ctxt_handle_.get(), buffers.desc());
@@ -62,7 +62,8 @@ public:
   }
 
   void size_written(std::size_t size) {
-    BOOST_VERIFY(size == buffer_.size());
+    (void)(size);
+    assert(size == buffer_.size());
     buffer_ = sspi_context_buffer{};
   }
 

--- a/include/boost/wintls/error.hpp
+++ b/include/boost/wintls/error.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_WINTLS_ERROR_HPP
 #define BOOST_WINTLS_ERROR_HPP
 
+#include <boost/wintls/detail/config.hpp>
 #include <boost/wintls/detail/error.hpp>
 #include <boost/wintls/detail/sspi_types.hpp>
 
@@ -15,8 +16,8 @@ namespace boost {
 namespace wintls {
 namespace error {
 
-inline boost::system::error_code make_error_code(SECURITY_STATUS sc) {
-  return boost::system::error_code(static_cast<int>(sc), boost::system::system_category());
+inline wintls::error_code make_error_code(SECURITY_STATUS sc) {
+  return wintls::error_code(static_cast<int>(sc), wintls::system_category());
 }
 
 } // namespace error

--- a/include/boost/wintls/stream.hpp
+++ b/include/boost/wintls/stream.hpp
@@ -11,6 +11,7 @@
 #include <boost/wintls/error.hpp>
 #include <boost/wintls/handshake_type.hpp>
 
+#include <boost/wintls/detail/assert.hpp>
 #include <boost/wintls/detail/async_handshake.hpp>
 #include <boost/wintls/detail/async_read.hpp>
 #include <boost/wintls/detail/async_shutdown.hpp>
@@ -180,7 +181,7 @@ public:
           return;
         }
         case detail::sspi_handshake::state::done:
-          std::abort(); // unreachable here
+          WINTLS_UNREACHABLE_RETURN(0);
       }
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(test_sources
   tls_record.cpp
   error_test.cpp
   handshake_test.cpp
+  ocsp_responder.cpp
   certificate_test.cpp
   sspi_buffer_sequence_test.cpp
   stream_test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 Include(FetchContent)
 
-find_package(Boost COMPONENTS filesystem)
+if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
+  find_package(Boost COMPONENTS filesystem)
+endif()
 find_package(OpenSSL COMPONENTS SSL Crypto)
 find_package(Threads)
 
@@ -58,16 +60,23 @@ target_link_libraries(unittest PRIVATE
   OpenSSL::Crypto
   Threads::Threads
   Catch2::Catch2
-  Boost::filesystem
   boost-wintls
 )
 
-if(MSVC AND ${Boost_VERSION} VERSION_LESS "1.79" AND ${OPENSSL_VERSION} VERSION_GREATER_EQUAL "3.0")
-  # A bit of a hack. Older Boost.Asio versions use OpenSSL functions
-  # deprecated in version 3.0 so disable warnings on use of deprecated
-  # functions on MSVC where OpenSSL headers are not included as system
-  # headers.
-  target_compile_options(unittest PRIVATE /wd4996)
+if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
+  target_link_libraries(unittest PRIVATE
+    Boost::filesystem
+  )
+endif()
+
+if(DEFINED Boost_VERSION)
+  if(MSVC AND ${Boost_VERSION} VERSION_LESS "1.79" AND ${OPENSSL_VERSION} VERSION_GREATER_EQUAL "3.0")
+    # A bit of a hack. Older Boost.Asio versions use OpenSSL functions
+    # deprecated in version 3.0 so disable warnings on use of deprecated
+    # functions on MSVC where OpenSSL headers are not included as system
+    # headers.
+    target_compile_options(unittest PRIVATE /wd4996)
+  endif()
 endif()
 
 include(CTest)

--- a/test/asio_ssl_client_stream.hpp
+++ b/test/asio_ssl_client_stream.hpp
@@ -30,7 +30,7 @@ struct asio_ssl_client_context : public asio_ssl::context {
   }
 
   void enable_server_verify() {
-    set_verify_mode(boost::asio::ssl::verify_peer);
+    set_verify_mode(net::ssl::verify_peer);
   }
 
 private:

--- a/test/async_echo_client.hpp
+++ b/test/async_echo_client.hpp
@@ -32,7 +32,7 @@ public:
 private:
   void do_handshake() {
     stream.async_handshake(Stream::handshake_type::client,
-                           [this](const boost::system::error_code& ec) {
+                           [this](const error_code& ec) {
                              REQUIRE_FALSE(ec);
                              do_write();
                            });
@@ -40,7 +40,7 @@ private:
 
   void do_write() {
     net::async_write(stream, net::buffer(message_),
-                     [this](const boost::system::error_code& ec, std::size_t) {
+                     [this](const error_code& ec, std::size_t) {
                        REQUIRE_FALSE(ec);
                        do_read();
                      });
@@ -48,14 +48,14 @@ private:
 
   void do_read() {
     net::async_read_until(stream, recv_buffer_, '\0',
-                          [this](const boost::system::error_code& ec, std::size_t) {
+                          [this](const error_code& ec, std::size_t) {
                             REQUIRE_FALSE(ec);
                             do_shutdown();
                           });
   }
 
   void do_shutdown() {
-    stream.async_shutdown([](const boost::system::error_code& ec) {
+    stream.async_shutdown([](const error_code& ec) {
       REQUIRE_FALSE(ec);
     });
   }

--- a/test/async_echo_server.hpp
+++ b/test/async_echo_server.hpp
@@ -27,7 +27,7 @@ public:
 
   virtual void do_handshake() {
     stream.async_handshake(Stream::handshake_type::server,
-                           [this](const boost::system::error_code& ec) {
+                           [this](const error_code& ec) {
                              REQUIRE_FALSE(ec);
                              do_read();
                            });
@@ -35,7 +35,7 @@ public:
 
   virtual void do_read() {
     net::async_read_until(stream, recv_buffer_, '\0',
-                          [this](const boost::system::error_code& ec, std::size_t) {
+                          [this](const error_code& ec, std::size_t) {
                             REQUIRE_FALSE(ec);
                             do_write();
                           });
@@ -43,19 +43,19 @@ public:
 
   virtual void do_write() {
     net::async_write(stream, recv_buffer_,
-                     [this](const boost::system::error_code& ec, std::size_t) {
+                     [this](const error_code& ec, std::size_t) {
                        REQUIRE_FALSE(ec);
                        do_shutdown();
                      });
   }
 
   virtual void do_shutdown() {
-    stream.async_shutdown([](const boost::system::error_code& ec) {
+    stream.async_shutdown([](const error_code& ec) {
       REQUIRE_FALSE(ec);
     });
   }
 
-  boost::asio::streambuf recv_buffer_;
+  net::streambuf recv_buffer_;
 };
 
 #endif // BOOST_WINTLS_TEST_ASYNC_ECHO_SERVER_HPP

--- a/test/echo_server.hpp
+++ b/test/echo_server.hpp
@@ -21,17 +21,17 @@ public:
     : Stream(context) {
   }
 
-  std::future<boost::system::error_code> handshake() {
+  std::future<error_code> handshake() {
     return std::async(std::launch::async, [this]() {
-      boost::system::error_code ec{};
+      error_code ec{};
       stream.handshake(Stream::handshake_type::server, ec);
       return ec;
     });
   }
 
-  std::future<boost::system::error_code> shutdown() {
+  std::future<error_code> shutdown() {
     return std::async(std::launch::async, [this]() {
-      boost::system::error_code ec{};
+      error_code ec{};
       stream.shutdown(ec);
       return ec;
     });

--- a/test/error_test.cpp
+++ b/test/error_test.cpp
@@ -15,20 +15,24 @@ TEST_CASE("SECURITY_STATUS error code") {
   auto sc = static_cast<SECURITY_STATUS>(0x80090326);
   auto ec = boost::wintls::error::make_error_code(sc);
   CHECK(ec.value() == sc);
-  CHECK(ec.message() == "The message received was unexpected or badly formatted");
+  // Boost will trim line breaks as well as periods from the original error message.
+  std::string msg = "The message received was unexpected or badly formatted";
+  CHECK((ec.message() == msg || ec.message() == msg + "."));
 }
 
 TEST_CASE("throw last error") {
-  boost::system::system_error error{boost::system::error_code{}};
+  system_error error{error_code{}};
   REQUIRE_FALSE(error.code());
 
   ::SetLastError(0x00000053);
   try {
     boost::wintls::detail::throw_last_error("YetAnotherUglyWindowsAPIFunctionEx3");
-  } catch (const boost::system::system_error& ex) {
+  } catch (const system_error& ex) {
     error = ex;
   }
   CHECK(error.code().value() == 0x00000053);
-  CHECK(error.code().message() == "Fail on INT 24");
+  // Boost will trim line breaks as well as periods from the original error message.
+  std::string msg = "Fail on INT 24";
+  CHECK((error.code().message() == msg || error.code().message() == msg + "."));
   CHECK_THAT(error.what(), Catch::Contains("YetAnotherUglyWindowsAPIFunctionEx3: Fail on INT 24"));
 }

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -568,7 +568,7 @@ TEST_CASE("failing handshakes") {
                                   [&buffer, &server_stream](const error_code&, std::size_t length) {
                                     tls_record rec(net::buffer(buffer, length));
                                     REQUIRE(rec.type == tls_record::record_type::handshake);
-                                    auto handshake = boost::get<tls_handshake>(rec.message);
+                                    auto handshake = variant::get<tls_handshake>(rec.message);
                                     REQUIRE(handshake.type == tls_handshake::handshake_type::client_hello);
                                     // Echoing the client_hello message back should cause the handshake to fail
                                     net::write(server_stream, net::buffer(buffer));

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -67,7 +67,7 @@ std::ostream& operator<<(std::ostream& os, const method meth) {
     case method::tlsv13_server:
       return os << "tlsv13_server";
   }
-  BOOST_UNREACHABLE_RETURN(0);
+  WINTLS_UNREACHABLE_RETURN(0);
 }
 
 } // namespace wintls

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
   // comparing potentially localized message strings.
   SetThreadUILanguage(MAKELCID(MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), SORT_DEFAULT));
 
-  boost::system::error_code ec;
+  error_code ec;
   boost::wintls::delete_private_key(test_key_name, ec);
   boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, test_key_name, ec);
   if (ec) {

--- a/test/ocsp_responder.cpp
+++ b/test/ocsp_responder.cpp
@@ -1,0 +1,41 @@
+﻿//
+// Copyright (c) 2021 Kasper Laudrup (laudrup at stacktrace dot dk)
+// Copyright (c) 2023 windowsair
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// Boost.Process misses an algorithm include in Boost 1.77,
+// see https://github.com/boostorg/process/issues/213.
+#include <algorithm>
+#include <boost/process.hpp>
+
+#include "ocsp_responder.hpp"
+
+struct ocsp_responder::ocsp_responder_impl {
+  boost::process::child child;
+};
+
+// Start an OCSP responder at http://localhost:5000 that can provide OCSP responses for
+// test certificates signed by test_certificates/ca_intermediate.crt.
+ocsp_responder::ocsp_responder() {
+  auto path = boost::process::search_path("openssl.exe");
+  auto args = boost::process::args({"ocsp",
+                                    "-CApath", TEST_CERTIFICATES_PATH,
+                                    "-index", TEST_CERTIFICATES_PATH "certindex",
+                                    "-port", "5000",
+                                    "-nmin", "1",
+                                    "-rkey", TEST_CERTIFICATES_PATH "ocsp_signer_ca_intermediate.key",
+                                    "-rsigner", TEST_CERTIFICATES_PATH "ocsp_signer_ca_intermediate.crt",
+                                    "-CA", TEST_CERTIFICATES_PATH "ca_intermediate.crt"});
+
+  impl_ = std::make_unique<ocsp_responder::ocsp_responder_impl>();
+  impl_->child = boost::process::child(path, args, boost::process::std_out > boost::process::null);
+}
+
+ocsp_responder::~ocsp_responder() = default;
+
+bool ocsp_responder::running() {
+  return impl_->child.running();
+}

--- a/test/ocsp_responder.hpp
+++ b/test/ocsp_responder.hpp
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2021 Kasper Laudrup (laudrup at stacktrace dot dk)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/test/ocsp_responder.hpp
+++ b/test/ocsp_responder.hpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2021 Kasper Laudrup (laudrup at stacktrace dot dk)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,24 +8,16 @@
 #ifndef BOOST_WINTLS_OCSP_RESPONDER_HPP
 #define BOOST_WINTLS_OCSP_RESPONDER_HPP
 
-// Boost.Process misses an algorithm include in Boost 1.77,
-// see https://github.com/boostorg/process/issues/213.
-#include <algorithm>
-#include <boost/process.hpp>
+#include <memory>
 
-// Start an OCSP responder at http://localhost:5000 that can provide OCSP responses for
-// test certificates signed by test_certificates/ca_intermediate.crt.
-inline boost::process::child start_ocsp_responder() {
-  auto path = boost::process::search_path("openssl.exe");
-  auto args = boost::process::args({"ocsp",
-                                    "-CApath", TEST_CERTIFICATES_PATH,
-                                    "-index", TEST_CERTIFICATES_PATH "certindex",
-                                    "-port", "5000",
-                                    "-nmin", "1",
-                                    "-rkey", TEST_CERTIFICATES_PATH "ocsp_signer_ca_intermediate.key",
-                                    "-rsigner", TEST_CERTIFICATES_PATH "ocsp_signer_ca_intermediate.crt",
-                                    "-CA", TEST_CERTIFICATES_PATH "ca_intermediate.crt"});
-  return boost::process::child(path, args, boost::process::std_out > boost::process::null);
-}
+class ocsp_responder {
+protected:
+  struct ocsp_responder_impl;
+  std::unique_ptr<ocsp_responder_impl> impl_;
+public:
+  ocsp_responder();
+  ~ocsp_responder();
+  bool running();
+};
 
 #endif

--- a/test/tls_record.cpp
+++ b/test/tls_record.cpp
@@ -5,6 +5,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <boost/wintls/detail/assert.hpp>
 #include "tls_record.hpp"
 
 namespace {
@@ -22,14 +23,14 @@ std::uint32_t net_to_host(std::uint32_t value) {
 
 template <typename SizeType>
 SizeType read_value(net::const_buffer& buffer) {
-  BOOST_ASSERT(buffer.size() >= sizeof(SizeType));
+  assert(buffer.size() >= sizeof(SizeType));
   SizeType ret = *reinterpret_cast<const SizeType*>(buffer.data());
   buffer += sizeof(SizeType);
   return net_to_host(ret);
 }
 
 std::uint32_t read_three_byte_value(net::const_buffer& buffer) {
-  BOOST_ASSERT(buffer.size() >= 3);
+  assert(buffer.size() >= 3);
   std::array<char, 4> value{};
   std::copy_n(reinterpret_cast<const char*>(buffer.data()), 3, value.begin() + 1);
   buffer += 3;
@@ -47,7 +48,7 @@ tls_record::message_type read_message(tls_record::record_type type, net::const_b
     case tls_record::record_type::application_data:
       return tls_application_data{};
   }
-  BOOST_UNREACHABLE_RETURN(0);
+  WINTLS_UNREACHABLE_RETURN(0);
 }
 
 tls_handshake::message_type read_message(tls_handshake::handshake_type t, net::const_buffer&) {
@@ -73,7 +74,7 @@ tls_handshake::message_type read_message(tls_handshake::handshake_type t, net::c
     case tls_handshake::handshake_type::finished:
       return tls_handshake::finished{};
   }
-  BOOST_UNREACHABLE_RETURN(0);
+  WINTLS_UNREACHABLE_RETURN(0);
 }
 
 } // namespace

--- a/test/tls_record.hpp
+++ b/test/tls_record.hpp
@@ -9,7 +9,13 @@
 
 #include "unittest.hpp"
 
-#include <boost/variant.hpp>
+#if __cplusplus >= 201703L || (defined _MSVC_LANG && _MSVC_LANG >= 201703L)
+#include <variant>
+namespace variant = std;
+#else
+#include "utils/impl/variant.hpp"
+namespace variant = nonstd;
+#endif
 
 #include <cstdint>
 
@@ -83,16 +89,16 @@ struct tls_handshake {
     // TODO: Implement
   };
 
-  using message_type = boost::variant<hello_request,
-                                      client_hello,
-                                      server_hello,
-                                      certificate,
-                                      server_key_exchange,
-                                      certificate_request,
-                                      server_done,
-                                      certificate_verify,
-                                      client_key_exchange,
-                                      finished>;
+  using message_type = variant::variant<hello_request,
+                                        client_hello,
+                                        server_hello,
+                                        certificate,
+                                        server_key_exchange,
+                                        certificate_request,
+                                        server_done,
+                                        certificate_verify,
+                                        client_key_exchange,
+                                        finished>;
 
   tls_handshake(net::const_buffer data);
 
@@ -113,10 +119,10 @@ struct tls_record {
     application_data = 0x17
   };
 
-  using message_type = boost::variant<tls_change_cipher_spec,
-                                      tls_alert,
-                                      tls_handshake,
-                                      tls_application_data>;
+  using message_type = variant::variant<tls_change_cipher_spec,
+                                        tls_alert,
+                                        tls_handshake,
+                                        tls_application_data>;
   tls_record(net::const_buffer data);
 
   record_type type;

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -14,8 +14,12 @@
 #include <boost/make_shared.hpp>
 #endif
 
-#include <boost/beast/_experimental/test/stream.hpp>
+#include "utils/stream.hpp"
+#ifdef WINTLS_USE_STANDALONE_ASIO
+#include <asio/ssl.hpp>
+#else
 #include <boost/asio/ssl.hpp>
+#endif
 
 #include <catch2/catch.hpp>
 
@@ -26,8 +30,8 @@
 
 namespace Catch {
 template<>
-struct StringMaker<boost::system::error_code> {
-  static std::string convert(const boost::system::error_code& ec) {
+struct StringMaker<error_code> {
+  static std::string convert(const error_code& ec) {
     std::ostringstream oss;
     oss << ec.message() << " (0x" << std::hex << ec.value() << ")";
     return oss.str();
@@ -44,7 +48,11 @@ inline std::vector<unsigned char> bytes_from_file(const std::string& path) {
 }
 
 namespace net = boost::wintls::net;
+#ifdef WINTLS_USE_STANDALONE_ASIO
+namespace asio_ssl = asio::ssl;
+#else
 namespace asio_ssl = boost::asio::ssl;
-using test_stream = boost::beast::test::stream;
+#endif
+using test_stream = boost::wintls::test::stream;
 
 #endif // BOOST_WINTLS_UNITTEST_HPP

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -9,11 +9,6 @@
 
 #include <boost/wintls/detail/config.hpp>
 
-// Workaround missing include in boost 1.76 and 1.77 in beast::test::stream
-#if (BOOST_VERSION / 100 % 1000) == 77 || (BOOST_VERSION / 100 % 1000) == 76
-#include <boost/make_shared.hpp>
-#endif
-
 #include "utils/stream.hpp"
 #ifdef WINTLS_USE_STANDALONE_ASIO
 #include <asio/ssl.hpp>

--- a/test/utils/allocator.hpp
+++ b/test/utils/allocator.hpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_ALLOCATOR_HPP
+#define BOOST_BEAST_DETAIL_ALLOCATOR_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+#include <boost/container/allocator_traits.hpp>
+#else
+#include <memory>
+#endif
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+// This is a workaround for allocator_traits
+// implementations which falsely claim C++11
+// compatibility.
+
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+template<class Alloc>
+using allocator_traits = boost::container::allocator_traits<Alloc>;
+
+#else
+template<class Alloc>
+using allocator_traits = std::allocator_traits<Alloc>;
+
+#endif
+
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/test/utils/allocator.hpp
+++ b/test/utils/allocator.hpp
@@ -10,33 +10,21 @@
 #ifndef BOOST_BEAST_DETAIL_ALLOCATOR_HPP
 #define BOOST_BEAST_DETAIL_ALLOCATOR_HPP
 
-#include <boost/config.hpp>
-#ifdef BOOST_NO_CXX11_ALLOCATOR
-#include <boost/container/allocator_traits.hpp>
-#else
 #include <memory>
-#endif
 
 namespace boost {
-namespace beast {
-namespace detail {
+namespace wintls {
+namespace test {
 
 // This is a workaround for allocator_traits
 // implementations which falsely claim C++11
 // compatibility.
-
-#ifdef BOOST_NO_CXX11_ALLOCATOR
-template<class Alloc>
-using allocator_traits = boost::container::allocator_traits<Alloc>;
-
-#else
 template<class Alloc>
 using allocator_traits = std::allocator_traits<Alloc>;
 
-#endif
 
-} // detail
-} // beast
+} // test
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/config.hpp
+++ b/test/utils/config.hpp
@@ -1,0 +1,28 @@
+#ifndef WINTLS_TEST_UTILS_CONFIG_HPP
+#define WINTLS_TEST_UTILS_CONFIG_HPP
+
+#ifdef WINTLS_USE_STANDALONE_ASIO
+#include <system_error>
+#include <asio.hpp>
+#else
+#include <boost/config.hpp>
+#include <boost/system/system_error.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/asio.hpp>
+#endif
+
+#ifdef WINTLS_USE_STANDALONE_ASIO
+namespace net = asio;
+using system_error = std::system_error;
+using error_code = std::error_code;
+using error_category = std::error_category;
+using error_condition = std::error_condition;
+#else
+namespace net = boost::asio;
+using system_error = boost::system::system_error;
+using error_code = boost::system::error_code;
+using error_category = boost::system::error_category;
+using error_condition = boost::system::error_condition;
+#endif
+
+#endif

--- a/test/utils/empty_value.hpp
+++ b/test/utils/empty_value.hpp
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef BOOST_CORE_EMPTY_VALUE_HPP
+#define BOOST_CORE_EMPTY_VALUE_HPP
+
+#include <boost/config.hpp>
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#include <utility>
+#endif
+
+#if defined(BOOST_GCC_VERSION) && (BOOST_GCC_VERSION >= 40700)
+#define BOOST_DETAIL_EMPTY_VALUE_BASE
+#elif defined(BOOST_INTEL) && defined(_MSC_VER) && (_MSC_VER >= 1800)
+#define BOOST_DETAIL_EMPTY_VALUE_BASE
+#elif defined(BOOST_MSVC) && (BOOST_MSVC >= 1800)
+#define BOOST_DETAIL_EMPTY_VALUE_BASE
+#elif defined(BOOST_CLANG) && !defined(__CUDACC__)
+#if __has_feature(is_empty) && __has_feature(is_final)
+#define BOOST_DETAIL_EMPTY_VALUE_BASE
+#endif
+#endif
+
+namespace boost {
+
+template<class T>
+struct use_empty_value_base {
+    enum {
+#if defined(BOOST_DETAIL_EMPTY_VALUE_BASE)
+        value = __is_empty(T) && !__is_final(T)
+#else
+        value = false
+#endif
+    };
+};
+
+struct empty_init_t { };
+
+namespace empty_ {
+
+template<class T, unsigned N = 0,
+    bool E = boost::use_empty_value_base<T>::value>
+class empty_value {
+public:
+    typedef T type;
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    empty_value() = default;
+#else
+    empty_value() { }
+#endif
+
+    empty_value(boost::empty_init_t)
+        : value_() { }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    template<class... Args>
+    explicit empty_value(boost::empty_init_t, Args&&... args)
+        : value_(std::forward<Args>(args)...) { }
+#else
+    template<class U>
+    empty_value(boost::empty_init_t, U&& value)
+        : value_(std::forward<U>(value)) { }
+#endif
+#else
+    template<class U>
+    empty_value(boost::empty_init_t, const U& value)
+        : value_(value) { }
+
+    template<class U>
+    empty_value(boost::empty_init_t, U& value)
+        : value_(value) { }
+#endif
+
+    const T& get() const BOOST_NOEXCEPT {
+        return value_;
+    }
+
+    T& get() BOOST_NOEXCEPT {
+        return value_;
+    }
+
+private:
+    T value_;
+};
+
+#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
+template<class T, unsigned N>
+class empty_value<T, N, true>
+    : T {
+public:
+    typedef T type;
+
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+    empty_value() = default;
+#else
+    empty_value() { }
+#endif
+
+    empty_value(boost::empty_init_t)
+        : T() { }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    template<class... Args>
+    explicit empty_value(boost::empty_init_t, Args&&... args)
+        : T(std::forward<Args>(args)...) { }
+#else
+    template<class U>
+    empty_value(boost::empty_init_t, U&& value)
+        : T(std::forward<U>(value)) { }
+#endif
+#else
+    template<class U>
+    empty_value(boost::empty_init_t, const U& value)
+        : T(value) { }
+
+    template<class U>
+    empty_value(boost::empty_init_t, U& value)
+        : T(value) { }
+#endif
+
+    const T& get() const BOOST_NOEXCEPT {
+        return *this;
+    }
+
+    T& get() BOOST_NOEXCEPT {
+        return *this;
+    }
+};
+#endif
+
+} /* empty_ */
+
+using empty_::empty_value;
+
+} /* boost */
+
+#endif

--- a/test/utils/empty_value.hpp
+++ b/test/utils/empty_value.hpp
@@ -8,33 +8,15 @@ Distributed under the Boost Software License, Version 1.0.
 #ifndef BOOST_CORE_EMPTY_VALUE_HPP
 #define BOOST_CORE_EMPTY_VALUE_HPP
 
-#include <boost/config.hpp>
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #include <utility>
-#endif
-
-#if defined(BOOST_GCC_VERSION) && (BOOST_GCC_VERSION >= 40700)
-#define BOOST_DETAIL_EMPTY_VALUE_BASE
-#elif defined(BOOST_INTEL) && defined(_MSC_VER) && (_MSC_VER >= 1800)
-#define BOOST_DETAIL_EMPTY_VALUE_BASE
-#elif defined(BOOST_MSVC) && (BOOST_MSVC >= 1800)
-#define BOOST_DETAIL_EMPTY_VALUE_BASE
-#elif defined(BOOST_CLANG) && !defined(__CUDACC__)
-#if __has_feature(is_empty) && __has_feature(is_final)
-#define BOOST_DETAIL_EMPTY_VALUE_BASE
-#endif
-#endif
 
 namespace boost {
-
+namespace wintls {
+namespace test {
 template<class T>
 struct use_empty_value_base {
     enum {
-#if defined(BOOST_DETAIL_EMPTY_VALUE_BASE)
-        value = __is_empty(T) && !__is_final(T)
-#else
         value = false
-#endif
     };
 };
 
@@ -43,45 +25,25 @@ struct empty_init_t { };
 namespace empty_ {
 
 template<class T, unsigned N = 0,
-    bool E = boost::use_empty_value_base<T>::value>
+    bool E = boost::wintls::test::use_empty_value_base<T>::value>
 class empty_value {
 public:
     typedef T type;
 
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
     empty_value() = default;
-#else
-    empty_value() { }
-#endif
 
-    empty_value(boost::empty_init_t)
+    empty_value(boost::wintls::test::empty_init_t)
         : value_() { }
 
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     template<class... Args>
-    explicit empty_value(boost::empty_init_t, Args&&... args)
+    explicit empty_value(boost::wintls::test::empty_init_t, Args&&... args)
         : value_(std::forward<Args>(args)...) { }
-#else
-    template<class U>
-    empty_value(boost::empty_init_t, U&& value)
-        : value_(std::forward<U>(value)) { }
-#endif
-#else
-    template<class U>
-    empty_value(boost::empty_init_t, const U& value)
-        : value_(value) { }
 
-    template<class U>
-    empty_value(boost::empty_init_t, U& value)
-        : value_(value) { }
-#endif
-
-    const T& get() const BOOST_NOEXCEPT {
+    const T& get() const noexcept {
         return value_;
     }
 
-    T& get() BOOST_NOEXCEPT {
+    T& get() noexcept {
         return value_;
     }
 
@@ -89,56 +51,36 @@ private:
     T value_;
 };
 
-#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)
 template<class T, unsigned N>
 class empty_value<T, N, true>
     : T {
 public:
     typedef T type;
 
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
     empty_value() = default;
-#else
-    empty_value() { }
-#endif
 
-    empty_value(boost::empty_init_t)
+    empty_value(boost::wintls::test::empty_init_t)
         : T() { }
 
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     template<class... Args>
-    explicit empty_value(boost::empty_init_t, Args&&... args)
+    explicit empty_value(boost::wintls::test::empty_init_t, Args&&... args)
         : T(std::forward<Args>(args)...) { }
-#else
-    template<class U>
-    empty_value(boost::empty_init_t, U&& value)
-        : T(std::forward<U>(value)) { }
-#endif
-#else
-    template<class U>
-    empty_value(boost::empty_init_t, const U& value)
-        : T(value) { }
 
-    template<class U>
-    empty_value(boost::empty_init_t, U& value)
-        : T(value) { }
-#endif
-
-    const T& get() const BOOST_NOEXCEPT {
+    const T& get() const noexcept {
         return *this;
     }
 
-    T& get() BOOST_NOEXCEPT {
+    T& get() noexcept {
         return *this;
     }
 };
-#endif
 
 } /* empty_ */
 
 using empty_::empty_value;
 
+} /* test */
+} /* wintls */
 } /* boost */
 
 #endif

--- a/test/utils/error.hpp
+++ b/test/utils/error.hpp
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_ERROR_HPP
+#define BOOST_BEAST_TEST_ERROR_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/error.hpp>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+/// Error codes returned from unit testing algorithms
+enum class error
+{
+    /** The test stream generated a simulated testing error
+
+        This error is returned by a @ref fail_count object
+        when it generates a simulated error.
+    */
+    test_failure = 1
+};
+
+} // test
+} // beast
+} // boost
+
+#include <boost/beast/_experimental/test/impl/error.hpp>
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/_experimental/test/impl/error.ipp>
+#endif
+
+#endif

--- a/test/utils/error.hpp
+++ b/test/utils/error.hpp
@@ -10,11 +10,9 @@
 #ifndef BOOST_BEAST_TEST_ERROR_HPP
 #define BOOST_BEAST_TEST_ERROR_HPP
 
-#include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/core/error.hpp>
 
 namespace boost {
-namespace beast {
+namespace wintls {
 namespace test {
 
 /// Error codes returned from unit testing algorithms
@@ -29,12 +27,10 @@ enum class error
 };
 
 } // test
-} // beast
+} // wintls
 } // boost
 
-#include <boost/beast/_experimental/test/impl/error.hpp>
-#ifdef BOOST_BEAST_HEADER_ONLY
-#include <boost/beast/_experimental/test/impl/error.ipp>
-#endif
+#include "impl/error.ipp"
+#include "impl/error.hpp"
 
 #endif

--- a/test/utils/fail_count.hpp
+++ b/test/utils/fail_count.hpp
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_FAIL_COUNT_HPP
+#define BOOST_BEAST_TEST_FAIL_COUNT_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/_experimental/test/error.hpp>
+#include <cstdlib>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+/** A countdown to simulated failure
+
+    On the Nth operation, the class will fail with the specified
+    error code, or the default error code of @ref error::test_failure.
+
+    Instances of this class may be used to build objects which
+    are specifically designed to aid in writing unit tests, for
+    interfaces which can throw exceptions or return `error_code`
+    values representing failure.
+*/
+class fail_count
+{
+    std::size_t n_;
+    std::size_t i_ = 0;
+    error_code ec_;
+
+public:
+    fail_count(fail_count&&) = default;
+
+    /** Construct a counter
+
+        @param n The 0-based index of the operation to fail on or after
+        @param ev An optional error code to use when generating a simulated failure
+    */
+    BOOST_BEAST_DECL
+    explicit
+    fail_count(
+        std::size_t n,
+        error_code ev = error::test_failure);
+
+    /// Throw an exception on the Nth failure
+    BOOST_BEAST_DECL
+    void
+    fail();
+
+    /// Set an error code on the Nth failure
+    BOOST_BEAST_DECL
+    bool
+    fail(error_code& ec);
+};
+
+} // test
+} // beast
+} // boost
+
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/_experimental/test/impl/fail_count.ipp>
+#endif
+
+#endif

--- a/test/utils/fail_count.hpp
+++ b/test/utils/fail_count.hpp
@@ -10,12 +10,12 @@
 #ifndef BOOST_BEAST_TEST_FAIL_COUNT_HPP
 #define BOOST_BEAST_TEST_FAIL_COUNT_HPP
 
-#include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/_experimental/test/error.hpp>
+#include "config.hpp"
+#include "error.hpp"
 #include <cstdlib>
 
 namespace boost {
-namespace beast {
+namespace wintls {
 namespace test {
 
 /** A countdown to simulated failure
@@ -42,29 +42,27 @@ public:
         @param n The 0-based index of the operation to fail on or after
         @param ev An optional error code to use when generating a simulated failure
     */
-    BOOST_BEAST_DECL
+    inline
     explicit
     fail_count(
         std::size_t n,
         error_code ev = error::test_failure);
 
     /// Throw an exception on the Nth failure
-    BOOST_BEAST_DECL
+    inline
     void
     fail();
 
     /// Set an error code on the Nth failure
-    BOOST_BEAST_DECL
+    inline
     bool
     fail(error_code& ec);
 };
 
 } // test
-} // beast
+} // wintls
 } // boost
 
-#ifdef BOOST_BEAST_HEADER_ONLY
-#include <boost/beast/_experimental/test/impl/fail_count.ipp>
-#endif
+#include "impl/fail_count.ipp"
 
 #endif

--- a/test/utils/flat_buffer.hpp
+++ b/test/utils/flat_buffer.hpp
@@ -1,0 +1,533 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_FLAT_BUFFER_HPP
+#define BOOST_BEAST_FLAT_BUFFER_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/detail/allocator.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/core/empty_value.hpp>
+#include <limits>
+#include <memory>
+#include <type_traits>
+
+namespace boost {
+namespace beast {
+
+/** A dynamic buffer providing buffer sequences of length one.
+
+    A dynamic buffer encapsulates memory storage that may be
+    automatically resized as required, where the memory is
+    divided into two regions: readable bytes followed by
+    writable bytes. These memory regions are internal to
+    the dynamic buffer, but direct access to the elements
+    is provided to permit them to be efficiently used with
+    I/O operations.
+
+    Objects of this type meet the requirements of <em>DynamicBuffer</em>
+    and have the following additional properties:
+
+    @li A mutable buffer sequence representing the readable
+    bytes is returned by @ref data when `this` is non-const.
+
+    @li A configurable maximum buffer size may be set upon
+    construction. Attempts to exceed the buffer size will throw
+    `std::length_error`.
+
+    @li Buffer sequences representing the readable and writable
+    bytes, returned by @ref data and @ref prepare, will have
+    length one.
+
+    Upon construction, a maximum size for the buffer may be
+    specified. If this limit is exceeded, the `std::length_error`
+    exception will be thrown.
+
+    @note This class is designed for use with algorithms that
+    take dynamic buffers as parameters, and are optimized
+    for the case where the input sequence or output sequence
+    is stored in a single contiguous buffer.
+*/
+template<class Allocator>
+class basic_flat_buffer
+#if ! BOOST_BEAST_DOXYGEN
+    : private boost::empty_value<
+        typename detail::allocator_traits<Allocator>::
+            template rebind_alloc<char>>
+#endif
+{
+    template<class OtherAlloc>
+    friend class basic_flat_buffer;
+
+    using base_alloc_type = typename
+        detail::allocator_traits<Allocator>::
+            template rebind_alloc<char>;
+
+    static bool constexpr default_nothrow =
+        std::is_nothrow_default_constructible<Allocator>::value;
+
+    using alloc_traits =
+        beast::detail::allocator_traits<base_alloc_type>;
+
+    using pocma = typename
+        alloc_traits::propagate_on_container_move_assignment;
+
+    using pocca = typename
+        alloc_traits::propagate_on_container_copy_assignment;
+
+    static
+    std::size_t
+    dist(char const* first, char const* last) noexcept
+    {
+        return static_cast<std::size_t>(last - first);
+    }
+
+    char* begin_;
+    char* in_;
+    char* out_;
+    char* last_;
+    char* end_;
+    std::size_t max_;
+
+public:
+    /// The type of allocator used.
+    using allocator_type = Allocator;
+
+    /// Destructor
+    ~basic_flat_buffer();
+
+    /** Constructor
+
+        After construction, @ref capacity will return zero, and
+        @ref max_size will return the largest value which may
+        be passed to the allocator's `allocate` function.
+    */
+    basic_flat_buffer() noexcept(default_nothrow);
+
+    /** Constructor
+
+        After construction, @ref capacity will return zero, and
+        @ref max_size will return the specified value of `limit`.
+
+        @param limit The desired maximum size.
+    */
+    explicit
+    basic_flat_buffer(
+        std::size_t limit) noexcept(default_nothrow);
+
+    /** Constructor
+
+        After construction, @ref capacity will return zero, and
+        @ref max_size will return the largest value which may
+        be passed to the allocator's `allocate` function.
+
+        @param alloc The allocator to use for the object.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    explicit
+    basic_flat_buffer(Allocator const& alloc) noexcept;
+
+    /** Constructor
+
+        After construction, @ref capacity will return zero, and
+        @ref max_size will return the specified value of `limit`.
+
+        @param limit The desired maximum size.
+
+        @param alloc The allocator to use for the object.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    basic_flat_buffer(
+        std::size_t limit,
+        Allocator const& alloc) noexcept;
+
+    /** Move Constructor
+
+        The container is constructed with the contents of `other`
+        using move semantics. The maximum size will be the same
+        as the moved-from object.
+
+        Buffer sequences previously obtained from `other` using
+        @ref data or @ref prepare remain valid after the move.
+
+        @param other The object to move from. After the move, the
+        moved-from object will have zero capacity, zero readable
+        bytes, and zero writable bytes.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    basic_flat_buffer(basic_flat_buffer&& other) noexcept;
+
+    /** Move Constructor
+
+        Using `alloc` as the allocator for the new container, the
+        contents of `other` are moved. If `alloc != other.get_allocator()`,
+        this results in a copy. The maximum size will be the same
+        as the moved-from object.
+
+        Buffer sequences previously obtained from `other` using
+        @ref data or @ref prepare become invalid after the move.
+
+        @param other The object to move from. After the move,
+        the moved-from object will have zero capacity, zero readable
+        bytes, and zero writable bytes.
+
+        @param alloc The allocator to use for the object.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of `alloc`.
+    */
+    basic_flat_buffer(
+        basic_flat_buffer&& other,
+        Allocator const& alloc);
+
+    /** Copy Constructor
+
+        This container is constructed with the contents of `other`
+        using copy semantics. The maximum size will be the same
+        as the copied object.
+
+        @param other The object to copy from.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of the allocator.
+    */
+    basic_flat_buffer(basic_flat_buffer const& other);
+
+    /** Copy Constructor
+
+        This container is constructed with the contents of `other`
+        using copy semantics and the specified allocator. The maximum
+        size will be the same as the copied object.
+
+        @param other The object to copy from.
+
+        @param alloc The allocator to use for the object.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of `alloc`.
+    */
+    basic_flat_buffer(
+        basic_flat_buffer const& other,
+        Allocator const& alloc);
+
+    /** Copy Constructor
+
+        This container is constructed with the contents of `other`
+        using copy semantics. The maximum size will be the same
+        as the copied object.
+
+        @param other The object to copy from.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of the allocator.
+    */
+    template<class OtherAlloc>
+    basic_flat_buffer(
+        basic_flat_buffer<OtherAlloc> const& other)
+            noexcept(default_nothrow);
+
+    /** Copy Constructor
+
+        This container is constructed with the contents of `other`
+        using copy semantics. The maximum size will be the same
+        as the copied object.
+
+        @param other The object to copy from.
+
+        @param alloc The allocator to use for the object.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of `alloc`.
+    */
+    template<class OtherAlloc>
+    basic_flat_buffer(
+        basic_flat_buffer<OtherAlloc> const& other,
+        Allocator const& alloc);
+
+    /** Move Assignment
+
+        The container is assigned with the contents of `other`
+        using move semantics. The maximum size will be the same
+        as the moved-from object.
+
+        Buffer sequences previously obtained from `other` using
+        @ref data or @ref prepare remain valid after the move.
+
+        @param other The object to move from. After the move,
+        the moved-from object will have zero capacity, zero readable
+        bytes, and zero writable bytes.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    basic_flat_buffer&
+    operator=(basic_flat_buffer&& other) noexcept;
+
+    /** Copy Assignment
+
+        The container is assigned with the contents of `other`
+        using copy semantics. The maximum size will be the same
+        as the copied object.
+
+        After the copy, `this` will have zero writable bytes.
+
+        @param other The object to copy from.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of the allocator.
+    */
+    basic_flat_buffer&
+    operator=(basic_flat_buffer const& other);
+
+    /** Copy assignment
+
+        The container is assigned with the contents of `other`
+        using copy semantics. The maximum size will be the same
+        as the copied object.
+
+        After the copy, `this` will have zero writable bytes.
+
+        @param other The object to copy from.
+
+        @throws std::length_error if `other.size()` exceeds the
+        maximum allocation size of the allocator.
+    */
+    template<class OtherAlloc>
+    basic_flat_buffer&
+    operator=(basic_flat_buffer<OtherAlloc> const& other);
+
+    /// Returns a copy of the allocator used.
+    allocator_type
+    get_allocator() const
+    {
+        return this->get();
+    }
+
+    /** Set the maximum allowed capacity
+
+        This function changes the currently configured upper limit
+        on capacity to the specified value.
+
+        @param n The maximum number of bytes ever allowed for capacity.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    void
+    max_size(std::size_t n) noexcept
+    {
+        max_ = n;
+    }
+
+    /** Guarantee a minimum capacity
+
+        This function adjusts the internal storage (if necessary)
+        to guarantee space for at least `n` bytes.
+
+        Buffer sequences previously obtained using @ref data or
+        @ref prepare become invalid.
+
+        @param n The minimum number of byte for the new capacity.
+        If this value is greater than the maximum size, then the
+        maximum size will be adjusted upwards to this value.
+
+        @esafe
+
+        Basic guarantee.
+
+        @throws std::length_error if n is larger than the maximum
+        allocation size of the allocator.
+    */
+    void
+    reserve(std::size_t n);
+
+    /** Reallocate the buffer to fit the readable bytes exactly.
+
+        Buffer sequences previously obtained using @ref data or
+        @ref prepare become invalid.
+
+        @esafe
+
+        Strong guarantee.
+    */
+    void
+    shrink_to_fit();
+
+    /** Set the size of the readable and writable bytes to zero.
+
+        This clears the buffer without changing capacity.
+        Buffer sequences previously obtained using @ref data or
+        @ref prepare become invalid.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    void
+    clear() noexcept;
+
+    /// Exchange two dynamic buffers
+    template<class Alloc>
+    friend
+    void
+    swap(
+        basic_flat_buffer<Alloc>&,
+        basic_flat_buffer<Alloc>&);
+
+    //--------------------------------------------------------------------------
+
+    /// The ConstBufferSequence used to represent the readable bytes.
+    using const_buffers_type = net::const_buffer;
+
+    /// The MutableBufferSequence used to represent the readable bytes.
+    using mutable_data_type = net::mutable_buffer;
+
+    /// The MutableBufferSequence used to represent the writable bytes.
+    using mutable_buffers_type = net::mutable_buffer;
+
+    /// Returns the number of readable bytes.
+    std::size_t
+    size() const noexcept
+    {
+        return dist(in_, out_);
+    }
+
+    /// Return the maximum number of bytes, both readable and writable, that can ever be held.
+    std::size_t
+    max_size() const noexcept
+    {
+        return max_;
+    }
+
+    /// Return the maximum number of bytes, both readable and writable, that can be held without requiring an allocation.
+    std::size_t
+    capacity() const noexcept
+    {
+        return dist(begin_, end_);
+    }
+
+    /// Returns a constant buffer sequence representing the readable bytes
+    const_buffers_type
+    data() const noexcept
+    {
+        return {in_, dist(in_, out_)};
+    }
+
+    /// Returns a constant buffer sequence representing the readable bytes
+    const_buffers_type
+    cdata() const noexcept
+    {
+        return data();
+    }
+
+    /// Returns a mutable buffer sequence representing the readable bytes
+    mutable_data_type
+    data() noexcept
+    {
+        return {in_, dist(in_, out_)};
+    }
+
+    /** Returns a mutable buffer sequence representing writable bytes.
+    
+        Returns a mutable buffer sequence representing the writable
+        bytes containing exactly `n` bytes of storage. Memory may be
+        reallocated as needed.
+
+        All buffers sequences previously obtained using
+        @ref data or @ref prepare become invalid.
+
+        @param n The desired number of bytes in the returned buffer
+        sequence.
+
+        @throws std::length_error if `size() + n` exceeds either
+        `max_size()` or the allocator's maximum allocation size.
+
+        @esafe
+
+        Strong guarantee.
+    */
+    mutable_buffers_type
+    prepare(std::size_t n);
+
+    /** Append writable bytes to the readable bytes.
+
+        Appends n bytes from the start of the writable bytes to the
+        end of the readable bytes. The remainder of the writable bytes
+        are discarded. If n is greater than the number of writable
+        bytes, all writable bytes are appended to the readable bytes.
+
+        All buffers sequences previously obtained using
+        @ref data or @ref prepare become invalid.
+
+        @param n The number of bytes to append. If this number
+        is greater than the number of writable bytes, all
+        writable bytes are appended.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    void
+    commit(std::size_t n) noexcept
+    {
+        out_ += (std::min)(n, dist(out_, last_));
+    }
+
+    /** Remove bytes from beginning of the readable bytes.
+
+        Removes n bytes from the beginning of the readable bytes.
+
+        All buffers sequences previously obtained using
+        @ref data or @ref prepare become invalid.
+
+        @param n The number of bytes to remove. If this number
+        is greater than the number of readable bytes, all
+        readable bytes are removed.
+
+        @esafe
+
+        No-throw guarantee.
+    */
+    void
+    consume(std::size_t n) noexcept;
+
+private:
+    template<class OtherAlloc>
+    void copy_from(basic_flat_buffer<OtherAlloc> const& other);
+    void move_assign(basic_flat_buffer&, std::true_type);
+    void move_assign(basic_flat_buffer&, std::false_type);
+    void copy_assign(basic_flat_buffer const&, std::true_type);
+    void copy_assign(basic_flat_buffer const&, std::false_type);
+    void swap(basic_flat_buffer&);
+    void swap(basic_flat_buffer&, std::true_type);
+    void swap(basic_flat_buffer&, std::false_type);
+    char* alloc(std::size_t n);
+};
+
+/// A flat buffer which uses the default allocator.
+using flat_buffer =
+    basic_flat_buffer<std::allocator<char>>;
+
+} // beast
+} // boost
+
+#include <boost/beast/core/impl/flat_buffer.hpp>
+
+#endif

--- a/test/utils/flat_buffer.hpp
+++ b/test/utils/flat_buffer.hpp
@@ -10,16 +10,16 @@
 #ifndef BOOST_BEAST_FLAT_BUFFER_HPP
 #define BOOST_BEAST_FLAT_BUFFER_HPP
 
-#include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/core/detail/allocator.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/core/empty_value.hpp>
+#include "empty_value.hpp"
+#include "allocator.hpp"
+#include "config.hpp"
 #include <limits>
 #include <memory>
 #include <type_traits>
 
 namespace boost {
-namespace beast {
+namespace wintls {
+namespace test {
 
 /** A dynamic buffer providing buffer sequences of length one.
 
@@ -56,24 +56,22 @@ namespace beast {
 */
 template<class Allocator>
 class basic_flat_buffer
-#if ! BOOST_BEAST_DOXYGEN
-    : private boost::empty_value<
-        typename detail::allocator_traits<Allocator>::
+    : private boost::wintls::test::empty_value<
+        typename boost::wintls::test::allocator_traits<Allocator>::
             template rebind_alloc<char>>
-#endif
 {
     template<class OtherAlloc>
     friend class basic_flat_buffer;
 
     using base_alloc_type = typename
-        detail::allocator_traits<Allocator>::
+        boost::wintls::test::allocator_traits<Allocator>::
             template rebind_alloc<char>;
 
     static bool constexpr default_nothrow =
         std::is_nothrow_default_constructible<Allocator>::value;
 
     using alloc_traits =
-        beast::detail::allocator_traits<base_alloc_type>;
+        boost::wintls::test::allocator_traits<base_alloc_type>;
 
     using pocma = typename
         alloc_traits::propagate_on_container_move_assignment;
@@ -525,9 +523,10 @@ private:
 using flat_buffer =
     basic_flat_buffer<std::allocator<char>>;
 
-} // beast
+} // test
+} // wintls
 } // boost
 
-#include <boost/beast/core/impl/flat_buffer.hpp>
+#include "impl/flat_buffer.hpp"
 
 #endif

--- a/test/utils/impl/error.hpp
+++ b/test/utils/impl/error.hpp
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_IMPL_ERROR_HPP
+#define BOOST_BEAST_TEST_IMPL_ERROR_HPP
+
+#include <boost/beast/core/error.hpp>
+#include <boost/beast/core/string.hpp>
+#include <type_traits>
+
+namespace boost {
+namespace system {
+template<>
+struct is_error_code_enum<
+    boost::beast::test::error>
+        : std::true_type
+{
+};
+} // system
+} // boost
+
+namespace boost {
+namespace beast {
+namespace test {
+
+BOOST_BEAST_DECL
+error_code
+make_error_code(error e) noexcept;
+
+} // test
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/error.hpp
+++ b/test/utils/impl/error.hpp
@@ -10,31 +10,40 @@
 #ifndef BOOST_BEAST_TEST_IMPL_ERROR_HPP
 #define BOOST_BEAST_TEST_IMPL_ERROR_HPP
 
-#include <boost/beast/core/error.hpp>
-#include <boost/beast/core/string.hpp>
 #include <type_traits>
 
+#ifdef WINTLS_USE_STANDALONE_ASIO
+namespace std {
+template<>
+struct is_error_code_enum<
+    boost::wintls::test::error>
+        : std::true_type
+{
+};
+} // std
+#else
 namespace boost {
 namespace system {
 template<>
 struct is_error_code_enum<
-    boost::beast::test::error>
+    boost::wintls::test::error>
         : std::true_type
 {
 };
 } // system
 } // boost
+#endif
 
 namespace boost {
-namespace beast {
+namespace wintls {
 namespace test {
 
-BOOST_BEAST_DECL
+inline
 error_code
 make_error_code(error e) noexcept;
 
 } // test
-} // beast
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/error.ipp
+++ b/test/utils/impl/error.ipp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_IMPL_ERROR_IPP
+#define BOOST_BEAST_TEST_IMPL_ERROR_IPP
+
+#include <boost/beast/_experimental/test/error.hpp>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+namespace detail {
+
+class error_codes : public error_category
+{
+public:
+    BOOST_BEAST_DECL
+    const char*
+    name() const noexcept override
+    {
+        return "boost.beast.test";
+    }
+
+    BOOST_BEAST_DECL
+    std::string
+    message(int ev) const override
+    {
+        switch(static_cast<error>(ev))
+        {
+        default:
+        case error::test_failure: return
+            "An automatic unit test failure occurred";
+        }
+    }
+
+    BOOST_BEAST_DECL
+    error_condition
+    default_error_condition(int ev) const noexcept override
+    {
+        return error_condition{ev, *this};
+    }
+};
+
+} // detail
+
+error_code
+make_error_code(error e) noexcept
+{
+    static detail::error_codes const cat{};
+    return error_code{static_cast<
+        std::underlying_type<error>::type>(e), cat};
+}
+
+} // test
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/error.ipp
+++ b/test/utils/impl/error.ipp
@@ -10,25 +10,23 @@
 #ifndef BOOST_BEAST_TEST_IMPL_ERROR_IPP
 #define BOOST_BEAST_TEST_IMPL_ERROR_IPP
 
-#include <boost/beast/_experimental/test/error.hpp>
+#include "error.hpp"
 
 namespace boost {
-namespace beast {
+namespace wintls {
 namespace test {
-
-namespace detail {
 
 class error_codes : public error_category
 {
 public:
-    BOOST_BEAST_DECL
+    inline
     const char*
     name() const noexcept override
     {
         return "boost.beast.test";
     }
 
-    BOOST_BEAST_DECL
+    inline
     std::string
     message(int ev) const override
     {
@@ -40,7 +38,7 @@ public:
         }
     }
 
-    BOOST_BEAST_DECL
+    inline
     error_condition
     default_error_condition(int ev) const noexcept override
     {
@@ -48,18 +46,17 @@ public:
     }
 };
 
-} // detail
-
+inline
 error_code
-make_error_code(error e) noexcept
+make_error_code(boost::wintls::test::error e) noexcept
 {
-    static detail::error_codes const cat{};
+    static boost::wintls::test::error_codes const cat{};
     return error_code{static_cast<
         std::underlying_type<error>::type>(e), cat};
 }
 
 } // test
-} // beast
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/fail_count.ipp
+++ b/test/utils/impl/fail_count.ipp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_IMPL_FAIL_COUNT_IPP
+#define BOOST_BEAST_TEST_IMPL_FAIL_COUNT_IPP
+
+#include <boost/beast/_experimental/test/fail_count.hpp>
+#include <boost/throw_exception.hpp>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+fail_count::
+fail_count(
+    std::size_t n,
+    error_code ev)
+    : n_(n)
+    , ec_(ev)
+{
+}
+
+void
+fail_count::
+fail()
+{
+    if(i_ < n_)
+        ++i_;
+    if(i_ == n_)
+        BOOST_THROW_EXCEPTION(system_error{ec_});
+}
+
+bool
+fail_count::
+fail(error_code& ec)
+{
+    if(i_ < n_)
+        ++i_;
+    if(i_ == n_)
+    {
+        ec = ec_;
+        return true;
+    }
+    ec = {};
+    return false;
+}
+
+} // test
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/fail_count.ipp
+++ b/test/utils/impl/fail_count.ipp
@@ -10,11 +10,8 @@
 #ifndef BOOST_BEAST_TEST_IMPL_FAIL_COUNT_IPP
 #define BOOST_BEAST_TEST_IMPL_FAIL_COUNT_IPP
 
-#include <boost/beast/_experimental/test/fail_count.hpp>
-#include <boost/throw_exception.hpp>
-
 namespace boost {
-namespace beast {
+namespace wintls {
 namespace test {
 
 fail_count::
@@ -33,7 +30,7 @@ fail()
     if(i_ < n_)
         ++i_;
     if(i_ == n_)
-        BOOST_THROW_EXCEPTION(system_error{ec_});
+        throw system_error{ec_};
 }
 
 bool
@@ -52,7 +49,7 @@ fail(error_code& ec)
 }
 
 } // test
-} // beast
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/flat_buffer.hpp
+++ b/test/utils/impl/flat_buffer.hpp
@@ -1,0 +1,533 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_IMPL_FLAT_BUFFER_HPP
+#define BOOST_BEAST_IMPL_FLAT_BUFFER_HPP
+
+#include <boost/core/exchange.hpp>
+#include <boost/assert.hpp>
+#include <boost/throw_exception.hpp>
+#include <memory>
+#include <stdexcept>
+
+namespace boost {
+namespace beast {
+
+/*  Layout:
+
+      begin_     in_          out_        last_      end_
+        |<------->|<---------->|<---------->|<------->|
+                  |  readable  |  writable  |
+*/
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+~basic_flat_buffer()
+{
+    if(! begin_)
+        return;
+    alloc_traits::deallocate(
+        this->get(), begin_, capacity());
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer() noexcept(default_nothrow)
+    : begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(alloc_traits::max_size(
+        this->get()))
+{
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    std::size_t limit) noexcept(default_nothrow)
+    : begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(limit)
+{
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(Allocator const& alloc) noexcept
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, alloc)
+    , begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(alloc_traits::max_size(
+        this->get()))
+{
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    std::size_t limit,
+    Allocator const& alloc) noexcept
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, alloc)
+    , begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(limit)
+{
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(basic_flat_buffer&& other) noexcept
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, std::move(other.get()))
+    , begin_(boost::exchange(other.begin_, nullptr))
+    , in_(boost::exchange(other.in_, nullptr))
+    , out_(boost::exchange(other.out_, nullptr))
+    , last_(boost::exchange(other.last_, nullptr))
+    , end_(boost::exchange(other.end_, nullptr))
+    , max_(other.max_)
+{
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    basic_flat_buffer&& other,
+    Allocator const& alloc)
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, alloc)
+{
+    if(this->get() != other.get())
+    {
+        begin_ = nullptr;
+        in_ = nullptr;
+        out_ = nullptr;
+        last_ = nullptr;
+        end_ = nullptr;
+        max_ = other.max_;
+        copy_from(other);
+        other.clear();
+        other.shrink_to_fit();
+        return;
+    }
+
+    begin_ = other.begin_;
+    in_ = other.in_;
+    out_ = other.out_;
+    last_ = other.out_; // invalidate
+    end_ = other.end_;
+    max_ = other.max_;
+    BOOST_ASSERT(
+        alloc_traits::max_size(this->get()) ==
+        alloc_traits::max_size(other.get()));
+    other.begin_ = nullptr;
+    other.in_ = nullptr;
+    other.out_ = nullptr;
+    other.last_ = nullptr;
+    other.end_ = nullptr;
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(basic_flat_buffer const& other)
+    : boost::empty_value<base_alloc_type>(boost::empty_init_t{},
+        alloc_traits::select_on_container_copy_construction(
+            other.get()))
+    , begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(other.max_)
+{
+    copy_from(other);
+}
+
+template<class Allocator>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    basic_flat_buffer const& other,
+    Allocator const& alloc)
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, alloc)
+    , begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(other.max_)
+{
+    copy_from(other);
+}
+
+template<class Allocator>
+template<class OtherAlloc>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    basic_flat_buffer<OtherAlloc> const& other)
+        noexcept(default_nothrow)
+    : begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(other.max_)
+{
+    copy_from(other);
+}
+
+template<class Allocator>
+template<class OtherAlloc>
+basic_flat_buffer<Allocator>::
+basic_flat_buffer(
+    basic_flat_buffer<OtherAlloc> const& other,
+    Allocator const& alloc)
+    : boost::empty_value<base_alloc_type>(
+        boost::empty_init_t{}, alloc)
+    , begin_(nullptr)
+    , in_(nullptr)
+    , out_(nullptr)
+    , last_(nullptr)
+    , end_(nullptr)
+    , max_(other.max_)
+{
+    copy_from(other);
+}
+
+template<class Allocator>
+auto
+basic_flat_buffer<Allocator>::
+operator=(basic_flat_buffer&& other) noexcept ->
+    basic_flat_buffer&
+{
+    if(this == &other)
+        return *this;
+    move_assign(other, pocma{});
+    return *this;
+}
+
+template<class Allocator>
+auto
+basic_flat_buffer<Allocator>::
+operator=(basic_flat_buffer const& other) ->
+    basic_flat_buffer&
+{
+    if(this == &other)
+        return *this;
+    copy_assign(other, pocca{});
+    return *this;
+}
+
+template<class Allocator>
+template<class OtherAlloc>
+auto
+basic_flat_buffer<Allocator>::
+operator=(
+    basic_flat_buffer<OtherAlloc> const& other) ->
+    basic_flat_buffer&
+{
+    copy_from(other);
+    return *this;
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+reserve(std::size_t n)
+{
+    if(max_ < n)
+        max_ = n;
+    if(n > capacity())
+        prepare(n - size());
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+shrink_to_fit()
+{
+    auto const len = size();
+    if(len == capacity())
+        return;
+    char* p;
+    if(len > 0)
+    {
+        BOOST_ASSERT(begin_);
+        BOOST_ASSERT(in_);
+        p = alloc(len);
+        std::memcpy(p, in_, len);
+    }
+    else
+    {
+        p = nullptr;
+    }
+    alloc_traits::deallocate(
+        this->get(), begin_, this->capacity());
+    begin_ = p;
+    in_ = begin_;
+    out_ = begin_ + len;
+    last_ = out_;
+    end_ = out_;
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+clear() noexcept
+{
+    in_ = begin_;
+    out_ = begin_;
+    last_ = begin_;
+}
+
+//------------------------------------------------------------------------------
+
+template<class Allocator>
+auto
+basic_flat_buffer<Allocator>::
+prepare(std::size_t n) ->
+    mutable_buffers_type
+{
+    auto const len = size();
+    if(len > max_ || n > (max_ - len))
+        BOOST_THROW_EXCEPTION(std::length_error{
+            "basic_flat_buffer too long"});
+    if(n <= dist(out_, end_))
+    {
+        // existing capacity is sufficient
+        last_ = out_ + n;
+        return{out_, n};
+    }
+    if(n <= capacity() - len)
+    {
+        // after a memmove,
+        // existing capacity is sufficient
+        if(len > 0)
+        {
+            BOOST_ASSERT(begin_);
+            BOOST_ASSERT(in_);
+            std::memmove(begin_, in_, len);
+        }
+        in_ = begin_;
+        out_ = in_ + len;
+        last_ = out_ + n;
+        return {out_, n};
+    }
+    // allocate a new buffer
+    auto const new_size = (std::min<std::size_t>)(
+        max_,
+        (std::max<std::size_t>)(2 * len, len + n));
+    auto const p = alloc(new_size);
+    if(begin_)
+    {
+        BOOST_ASSERT(p);
+        BOOST_ASSERT(in_);
+        std::memcpy(p, in_, len);
+        alloc_traits::deallocate(
+            this->get(), begin_, capacity());
+    }
+    begin_ = p;
+    in_ = begin_;
+    out_ = in_ + len;
+    last_ = out_ + n;
+    end_ = begin_ + new_size;
+    return {out_, n};
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+consume(std::size_t n) noexcept
+{
+    if(n >= dist(in_, out_))
+    {
+        in_ = begin_;
+        out_ = begin_;
+        return;
+    }
+    in_ += n;
+}
+
+//------------------------------------------------------------------------------
+
+template<class Allocator>
+template<class OtherAlloc>
+void
+basic_flat_buffer<Allocator>::
+copy_from(
+    basic_flat_buffer<OtherAlloc> const& other)
+{
+    std::size_t const n = other.size();
+    if(n == 0 || n > capacity())
+    {
+        if(begin_ != nullptr)
+        {
+            alloc_traits::deallocate(
+                this->get(), begin_,
+                this->capacity());
+            begin_ = nullptr;
+            in_ = nullptr;
+            out_ = nullptr;
+            last_ = nullptr;
+            end_ = nullptr;
+        }
+        if(n == 0)
+            return;
+        begin_ = alloc(n);
+        in_ = begin_;
+        out_ = begin_ + n;
+        last_ = begin_ + n;
+        end_ = begin_ + n;
+    }
+    in_ = begin_;
+    out_ = begin_ + n;
+    last_ = begin_ + n;
+    if(begin_)
+    {
+        BOOST_ASSERT(other.begin_);
+        std::memcpy(begin_, other.in_, n);
+    }
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+move_assign(basic_flat_buffer& other, std::true_type)
+{
+    clear();
+    shrink_to_fit();
+    this->get() = std::move(other.get());
+    begin_ = other.begin_;
+    in_ = other.in_;
+    out_ = other.out_;
+    last_ = out_;
+    end_ = other.end_;
+    max_ = other.max_;
+    other.begin_ = nullptr;
+    other.in_ = nullptr;
+    other.out_ = nullptr;
+    other.last_ = nullptr;
+    other.end_ = nullptr;
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+move_assign(basic_flat_buffer& other, std::false_type)
+{
+    if(this->get() != other.get())
+    {
+        copy_from(other);
+        other.clear();
+        other.shrink_to_fit();
+    }
+    else
+    {
+        move_assign(other, std::true_type{});
+    }
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+copy_assign(basic_flat_buffer const& other, std::true_type)
+{
+    max_ = other.max_;
+    this->get() = other.get();
+    copy_from(other);
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+copy_assign(basic_flat_buffer const& other, std::false_type)
+{
+    clear();
+    shrink_to_fit();
+    max_ = other.max_;
+    copy_from(other);
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+swap(basic_flat_buffer& other)
+{
+    swap(other, typename
+        alloc_traits::propagate_on_container_swap{});
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+swap(basic_flat_buffer& other, std::true_type)
+{
+    using std::swap;
+    swap(this->get(), other.get());
+    swap(max_, other.max_);
+    swap(begin_, other.begin_);
+    swap(in_, other.in_);
+    swap(out_, other.out_);
+    last_ = this->out_;
+    other.last_ = other.out_;
+    swap(end_, other.end_);
+}
+
+template<class Allocator>
+void
+basic_flat_buffer<Allocator>::
+swap(basic_flat_buffer& other, std::false_type)
+{
+    BOOST_ASSERT(this->get() == other.get());
+    using std::swap;
+    swap(max_, other.max_);
+    swap(begin_, other.begin_);
+    swap(in_, other.in_);
+    swap(out_, other.out_);
+    last_ = this->out_;
+    other.last_ = other.out_;
+    swap(end_, other.end_);
+}
+
+template<class Allocator>
+void
+swap(
+    basic_flat_buffer<Allocator>& lhs,
+    basic_flat_buffer<Allocator>& rhs)
+{
+    lhs.swap(rhs);
+}
+
+template<class Allocator>
+char*
+basic_flat_buffer<Allocator>::
+alloc(std::size_t n)
+{
+    if(n > alloc_traits::max_size(this->get()))
+        BOOST_THROW_EXCEPTION(std::length_error(
+            "A basic_flat_buffer exceeded the allocator's maximum size"));
+    return alloc_traits::allocate(this->get(), n);
+}
+
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/flat_buffer.hpp
+++ b/test/utils/impl/flat_buffer.hpp
@@ -10,14 +10,12 @@
 #ifndef BOOST_BEAST_IMPL_FLAT_BUFFER_HPP
 #define BOOST_BEAST_IMPL_FLAT_BUFFER_HPP
 
-#include <boost/core/exchange.hpp>
-#include <boost/assert.hpp>
-#include <boost/throw_exception.hpp>
 #include <memory>
 #include <stdexcept>
 
 namespace boost {
-namespace beast {
+namespace wintls {
+namespace test {
 
 /*  Layout:
 
@@ -65,8 +63,8 @@ basic_flat_buffer(
 template<class Allocator>
 basic_flat_buffer<Allocator>::
 basic_flat_buffer(Allocator const& alloc) noexcept
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, alloc)
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, alloc)
     , begin_(nullptr)
     , in_(nullptr)
     , out_(nullptr)
@@ -82,8 +80,8 @@ basic_flat_buffer<Allocator>::
 basic_flat_buffer(
     std::size_t limit,
     Allocator const& alloc) noexcept
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, alloc)
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, alloc)
     , begin_(nullptr)
     , in_(nullptr)
     , out_(nullptr)
@@ -96,13 +94,13 @@ basic_flat_buffer(
 template<class Allocator>
 basic_flat_buffer<Allocator>::
 basic_flat_buffer(basic_flat_buffer&& other) noexcept
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, std::move(other.get()))
-    , begin_(boost::exchange(other.begin_, nullptr))
-    , in_(boost::exchange(other.in_, nullptr))
-    , out_(boost::exchange(other.out_, nullptr))
-    , last_(boost::exchange(other.last_, nullptr))
-    , end_(boost::exchange(other.end_, nullptr))
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, std::move(other.get()))
+    , begin_(std::exchange(other.begin_, nullptr))
+    , in_(std::exchange(other.in_, nullptr))
+    , out_(std::exchange(other.out_, nullptr))
+    , last_(std::exchange(other.last_, nullptr))
+    , end_(std::exchange(other.end_, nullptr))
     , max_(other.max_)
 {
 }
@@ -112,8 +110,8 @@ basic_flat_buffer<Allocator>::
 basic_flat_buffer(
     basic_flat_buffer&& other,
     Allocator const& alloc)
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, alloc)
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, alloc)
 {
     if(this->get() != other.get())
     {
@@ -135,7 +133,7 @@ basic_flat_buffer(
     last_ = other.out_; // invalidate
     end_ = other.end_;
     max_ = other.max_;
-    BOOST_ASSERT(
+    assert(
         alloc_traits::max_size(this->get()) ==
         alloc_traits::max_size(other.get()));
     other.begin_ = nullptr;
@@ -148,7 +146,7 @@ basic_flat_buffer(
 template<class Allocator>
 basic_flat_buffer<Allocator>::
 basic_flat_buffer(basic_flat_buffer const& other)
-    : boost::empty_value<base_alloc_type>(boost::empty_init_t{},
+    : empty_value<base_alloc_type>(empty_init_t{},
         alloc_traits::select_on_container_copy_construction(
             other.get()))
     , begin_(nullptr)
@@ -166,8 +164,8 @@ basic_flat_buffer<Allocator>::
 basic_flat_buffer(
     basic_flat_buffer const& other,
     Allocator const& alloc)
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, alloc)
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, alloc)
     , begin_(nullptr)
     , in_(nullptr)
     , out_(nullptr)
@@ -200,8 +198,8 @@ basic_flat_buffer<Allocator>::
 basic_flat_buffer(
     basic_flat_buffer<OtherAlloc> const& other,
     Allocator const& alloc)
-    : boost::empty_value<base_alloc_type>(
-        boost::empty_init_t{}, alloc)
+    : empty_value<base_alloc_type>(
+        empty_init_t{}, alloc)
     , begin_(nullptr)
     , in_(nullptr)
     , out_(nullptr)
@@ -270,8 +268,8 @@ shrink_to_fit()
     char* p;
     if(len > 0)
     {
-        BOOST_ASSERT(begin_);
-        BOOST_ASSERT(in_);
+        assert(begin_);
+        assert(in_);
         p = alloc(len);
         std::memcpy(p, in_, len);
     }
@@ -308,8 +306,8 @@ prepare(std::size_t n) ->
 {
     auto const len = size();
     if(len > max_ || n > (max_ - len))
-        BOOST_THROW_EXCEPTION(std::length_error{
-            "basic_flat_buffer too long"});
+        throw std::length_error{
+            "basic_flat_buffer too long"};
     if(n <= dist(out_, end_))
     {
         // existing capacity is sufficient
@@ -322,8 +320,8 @@ prepare(std::size_t n) ->
         // existing capacity is sufficient
         if(len > 0)
         {
-            BOOST_ASSERT(begin_);
-            BOOST_ASSERT(in_);
+            assert(begin_);
+            assert(in_);
             std::memmove(begin_, in_, len);
         }
         in_ = begin_;
@@ -338,8 +336,8 @@ prepare(std::size_t n) ->
     auto const p = alloc(new_size);
     if(begin_)
     {
-        BOOST_ASSERT(p);
-        BOOST_ASSERT(in_);
+        assert(p);
+        assert(in_);
         std::memcpy(p, in_, len);
         alloc_traits::deallocate(
             this->get(), begin_, capacity());
@@ -402,7 +400,7 @@ copy_from(
     last_ = begin_ + n;
     if(begin_)
     {
-        BOOST_ASSERT(other.begin_);
+        assert(other.begin_);
         std::memcpy(begin_, other.in_, n);
     }
 }
@@ -496,7 +494,7 @@ void
 basic_flat_buffer<Allocator>::
 swap(basic_flat_buffer& other, std::false_type)
 {
-    BOOST_ASSERT(this->get() == other.get());
+    assert(this->get() == other.get());
     using std::swap;
     swap(max_, other.max_);
     swap(begin_, other.begin_);
@@ -522,12 +520,13 @@ basic_flat_buffer<Allocator>::
 alloc(std::size_t n)
 {
     if(n > alloc_traits::max_size(this->get()))
-        BOOST_THROW_EXCEPTION(std::length_error(
-            "A basic_flat_buffer exceeded the allocator's maximum size"));
+        throw std::length_error(
+            "A basic_flat_buffer exceeded the allocator's maximum size");
     return alloc_traits::allocate(this->get(), n);
 }
 
-} // beast
+} // test
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/is_invocable.hpp
+++ b/test/utils/impl/is_invocable.hpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_IS_INVOCABLE_HPP
+#define BOOST_BEAST_DETAIL_IS_INVOCABLE_HPP
+
+#include <type_traits>
+#include <utility>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template<class R, class C, class ...A>
+auto
+is_invocable_test(C&& c, int, A&& ...a)
+    -> decltype(std::is_convertible<
+        decltype(c(std::forward<A>(a)...)), R>::value ||
+            std::is_same<R, void>::value,
+                std::true_type());
+
+template<class R, class C, class ...A>
+std::false_type
+is_invocable_test(C&& c, long, A&& ...a);
+
+/** Metafunction returns `true` if F callable as R(A...)
+
+    Example:
+
+    @code
+    is_invocable<T, void(std::string)>::value
+    @endcode
+*/
+/** @{ */
+template<class C, class F>
+struct is_invocable : std::false_type
+{
+};
+
+template<class C, class R, class ...A>
+struct is_invocable<C, R(A...)>
+    : decltype(is_invocable_test<R>(
+        std::declval<C>(), 1, std::declval<A>()...))
+{
+};
+/** @} */
+
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/is_invocable.hpp
+++ b/test/utils/impl/is_invocable.hpp
@@ -14,8 +14,8 @@
 #include <utility>
 
 namespace boost {
-namespace beast {
-namespace detail {
+namespace wintls {
+namespace test {
 
 template<class R, class C, class ...A>
 auto
@@ -51,8 +51,8 @@ struct is_invocable<C, R(A...)>
 };
 /** @} */
 
-} // detail
-} // beast
+} // test
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/service_base.hpp
+++ b/test/utils/impl/service_base.hpp
@@ -10,11 +10,9 @@
 #ifndef BOOST_BEAST_DETAIL_SERVICE_BASE_HPP
 #define BOOST_BEAST_DETAIL_SERVICE_BASE_HPP
 
-#include <boost/asio/execution_context.hpp>
-
 namespace boost {
-namespace beast {
-namespace detail {
+namespace wintls {
+namespace test {
 
 template<class T>
 struct service_base : net::execution_context::service
@@ -31,8 +29,8 @@ struct service_base : net::execution_context::service
 template<class T>
 net::execution_context::id const service_base<T>::id;
 
-} // detail
-} // beast
+} // test
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/impl/stream.hpp
+++ b/test/utils/impl/stream.hpp
@@ -1,0 +1,456 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_IMPL_STREAM_HPP
+#define BOOST_BEAST_TEST_IMPL_STREAM_HPP
+
+#include <boost/beast/core/bind_handler.hpp>
+#include <boost/beast/core/buffer_traits.hpp>
+#include <boost/beast/core/detail/service_base.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+//------------------------------------------------------------------------------
+
+struct stream::service_impl
+{
+    std::mutex m_;
+    std::vector<state*> v_;
+
+    BOOST_BEAST_DECL
+    void
+    remove(state& impl);
+};
+
+class stream::service
+    : public beast::detail::service_base<service>
+{
+    boost::shared_ptr<service_impl> sp_;
+
+    BOOST_BEAST_DECL
+    void
+    shutdown() override;
+
+public:
+    BOOST_BEAST_DECL
+    explicit
+    service(net::execution_context& ctx);
+
+    BOOST_BEAST_DECL
+    static
+    auto
+    make_impl(
+        net::io_context& ctx,
+        test::fail_count* fc) ->
+            boost::shared_ptr<state>;
+};
+
+//------------------------------------------------------------------------------
+
+template<class Handler, class Buffers>
+class stream::read_op : public stream::read_op_base
+{
+    using ex1_type =
+        net::io_context::executor_type;
+    using ex2_type
+        = net::associated_executor_t<Handler, ex1_type>;
+
+    struct lambda
+    {
+        Handler h_;
+        boost::weak_ptr<state> wp_;
+        Buffers b_;
+        net::executor_work_guard<ex2_type> wg2_;
+
+        lambda(lambda&&) = default;
+        lambda(lambda const&) = default;
+
+        template<class Handler_>
+        lambda(
+            Handler_&& h,
+            boost::shared_ptr<state> const& s,
+            Buffers const& b)
+            : h_(std::forward<Handler_>(h))
+            , wp_(s)
+            , b_(b)
+            , wg2_(net::get_associated_executor(
+                h_, s->ioc.get_executor()))
+        {
+        }
+
+        void
+        operator()(error_code ec)
+        {
+            std::size_t bytes_transferred = 0;
+            auto sp = wp_.lock();
+            if(! sp)
+                ec = net::error::operation_aborted;
+            if(! ec)
+            {
+                std::lock_guard<std::mutex> lock(sp->m);
+                BOOST_ASSERT(! sp->op);
+                if(sp->b.size() > 0)
+                {
+                    bytes_transferred =
+                        net::buffer_copy(
+                            b_, sp->b.data(), sp->read_max);
+                    sp->b.consume(bytes_transferred);
+                    sp->nread_bytes += bytes_transferred;
+                }
+                else if (buffer_bytes(b_) > 0)
+                {
+                    ec = net::error::eof;
+                }
+            }
+
+            auto alloc = net::get_associated_allocator(h_);
+            wg2_.get_executor().dispatch(
+                beast::bind_front_handler(std::move(h_),
+                    ec, bytes_transferred), alloc);
+            wg2_.reset();
+        }
+    };
+
+    lambda fn_;
+    net::executor_work_guard<ex1_type> wg1_;
+
+public:
+    template<class Handler_>
+    read_op(
+        Handler_&& h,
+        boost::shared_ptr<state> const& s,
+        Buffers const& b)
+        : fn_(std::forward<Handler_>(h), s, b)
+        , wg1_(s->ioc.get_executor())
+    {
+    }
+
+    void
+    operator()(error_code ec) override
+    {
+
+        auto alloc = net::get_associated_allocator(fn_.h_);
+        wg1_.get_executor().post(
+            beast::bind_front_handler(std::move(fn_), ec), alloc);
+        wg1_.reset();
+    }
+};
+
+struct stream::run_read_op
+{
+    template<
+        class ReadHandler,
+        class MutableBufferSequence>
+    void
+    operator()(
+        ReadHandler&& h,
+        boost::shared_ptr<state> const& in,
+        MutableBufferSequence const& buffers)
+    {
+        // If you get an error on the following line it means
+        // that your handler does not meet the documented type
+        // requirements for the handler.
+
+        static_assert(
+            beast::detail::is_invocable<ReadHandler,
+                void(error_code, std::size_t)>::value,
+            "ReadHandler type requirements not met");
+
+        initiate_read(
+            in,
+            std::unique_ptr<read_op_base>{
+            new read_op<
+                typename std::decay<ReadHandler>::type,
+                MutableBufferSequence>(
+                    std::move(h),
+                    in,
+                    buffers)},
+            buffer_bytes(buffers));
+    }
+};
+
+struct stream::run_write_op
+{
+    template<
+        class WriteHandler,
+        class ConstBufferSequence>
+    void
+    operator()(
+        WriteHandler&& h,
+        boost::shared_ptr<state> in_,
+        boost::weak_ptr<state> out_,
+        ConstBufferSequence const& buffers)
+    {
+        // If you get an error on the following line it means
+        // that your handler does not meet the documented type
+        // requirements for the handler.
+
+        static_assert(
+            beast::detail::is_invocable<WriteHandler,
+                void(error_code, std::size_t)>::value,
+            "WriteHandler type requirements not met");
+
+        ++in_->nwrite;
+        auto const upcall = [&](error_code ec, std::size_t n)
+        {
+            net::post(
+                in_->ioc.get_executor(),
+                beast::bind_front_handler(std::move(h), ec, n));
+        };
+
+        // test failure
+        error_code ec;
+        std::size_t n = 0;
+        if(in_->fc && in_->fc->fail(ec))
+            return upcall(ec, n);
+
+        // A request to write 0 bytes to a stream is a no-op.
+        if(buffer_bytes(buffers) == 0)
+            return upcall(ec, n);
+
+        // connection closed
+        auto out = out_.lock();
+        if(! out)
+            return upcall(net::error::connection_reset, n);
+
+        // copy buffers
+        n = std::min<std::size_t>(
+            buffer_bytes(buffers), in_->write_max);
+        {
+            std::lock_guard<std::mutex> lock(out->m);
+            n = net::buffer_copy(out->b.prepare(n), buffers);
+            out->b.commit(n);
+            out->nwrite_bytes += n;
+            out->notify_read();
+        }
+        BOOST_ASSERT(! ec);
+        upcall(ec, n);
+    }
+};
+
+//------------------------------------------------------------------------------
+
+template<class MutableBufferSequence>
+std::size_t
+stream::
+read_some(MutableBufferSequence const& buffers)
+{
+    static_assert(net::is_mutable_buffer_sequence<
+            MutableBufferSequence>::value,
+        "MutableBufferSequence type requirements not met");
+    error_code ec;
+    auto const n = read_some(buffers, ec);
+    if(ec)
+        BOOST_THROW_EXCEPTION(system_error{ec});
+    return n;
+}
+
+template<class MutableBufferSequence>
+std::size_t
+stream::
+read_some(MutableBufferSequence const& buffers,
+    error_code& ec)
+{
+    static_assert(net::is_mutable_buffer_sequence<
+            MutableBufferSequence>::value,
+        "MutableBufferSequence type requirements not met");
+
+    ++in_->nread;
+
+    // test failure
+    if(in_->fc && in_->fc->fail(ec))
+        return 0;
+
+    // A request to read 0 bytes from a stream is a no-op.
+    if(buffer_bytes(buffers) == 0)
+    {
+        ec = {};
+        return 0;
+    }
+
+    std::unique_lock<std::mutex> lock{in_->m};
+    BOOST_ASSERT(! in_->op);
+    in_->cv.wait(lock,
+        [&]()
+        {
+            return
+                in_->b.size() > 0 ||
+                in_->code != status::ok;
+        });
+
+    // deliver bytes before eof
+    if(in_->b.size() > 0)
+    {
+        auto const n = net::buffer_copy(
+            buffers, in_->b.data(), in_->read_max);
+        in_->b.consume(n);
+        in_->nread_bytes += n;
+        return n;
+    }
+
+    // deliver error
+    BOOST_ASSERT(in_->code != status::ok);
+    ec = net::error::eof;
+    return 0;
+}
+
+template<class MutableBufferSequence, class ReadHandler>
+BOOST_BEAST_ASYNC_RESULT2(ReadHandler)
+stream::
+async_read_some(
+    MutableBufferSequence const& buffers,
+    ReadHandler&& handler)
+{
+    static_assert(net::is_mutable_buffer_sequence<
+            MutableBufferSequence>::value,
+        "MutableBufferSequence type requirements not met");
+
+    return net::async_initiate<
+        ReadHandler,
+        void(error_code, std::size_t)>(
+            run_read_op{},
+            handler,
+            in_,
+            buffers);
+}
+
+template<class ConstBufferSequence>
+std::size_t
+stream::
+write_some(ConstBufferSequence const& buffers)
+{
+    static_assert(net::is_const_buffer_sequence<
+            ConstBufferSequence>::value,
+        "ConstBufferSequence type requirements not met");
+    error_code ec;
+    auto const bytes_transferred =
+        write_some(buffers, ec);
+    if(ec)
+        BOOST_THROW_EXCEPTION(system_error{ec});
+    return bytes_transferred;
+}
+
+template<class ConstBufferSequence>
+std::size_t
+stream::
+write_some(
+    ConstBufferSequence const& buffers, error_code& ec)
+{
+    static_assert(net::is_const_buffer_sequence<
+            ConstBufferSequence>::value,
+        "ConstBufferSequence type requirements not met");
+
+    ++in_->nwrite;
+
+    // test failure
+    if(in_->fc && in_->fc->fail(ec))
+        return 0;
+
+    // A request to write 0 bytes to a stream is a no-op.
+    if(buffer_bytes(buffers) == 0)
+    {
+        ec = {};
+        return 0;
+    }
+
+    // connection closed
+    auto out = out_.lock();
+    if(! out)
+    {
+        ec = net::error::connection_reset;
+        return 0;
+    }
+
+    // copy buffers
+    auto n = std::min<std::size_t>(
+        buffer_bytes(buffers), in_->write_max);
+    {
+        std::lock_guard<std::mutex> lock(out->m);
+        n = net::buffer_copy(out->b.prepare(n), buffers);
+        out->b.commit(n);
+        out->nwrite_bytes += n;
+        out->notify_read();
+    }
+    return n;
+}
+
+template<class ConstBufferSequence, class WriteHandler>
+BOOST_BEAST_ASYNC_RESULT2(WriteHandler)
+stream::
+async_write_some(
+    ConstBufferSequence const& buffers,
+    WriteHandler&& handler)
+{
+    static_assert(net::is_const_buffer_sequence<
+            ConstBufferSequence>::value,
+        "ConstBufferSequence type requirements not met");
+
+    return net::async_initiate<
+        WriteHandler,
+        void(error_code, std::size_t)>(
+            run_write_op{},
+            handler,
+            in_,
+            out_,
+            buffers);
+}
+
+//------------------------------------------------------------------------------
+
+template<class TeardownHandler>
+void
+async_teardown(
+    role_type,
+    stream& s,
+    TeardownHandler&& handler)
+{
+    error_code ec;
+    if( s.in_->fc &&
+        s.in_->fc->fail(ec))
+        return net::post(
+            s.get_executor(),
+            beast::bind_front_handler(
+                std::move(handler), ec));
+    s.close();
+    if( s.in_->fc &&
+        s.in_->fc->fail(ec))
+        ec = net::error::eof;
+    else
+        ec = {};
+
+    net::post(
+        s.get_executor(),
+        beast::bind_front_handler(
+            std::move(handler), ec));
+}
+
+//------------------------------------------------------------------------------
+
+template<class Arg1, class... ArgN>
+stream
+connect(stream& to, Arg1&& arg1, ArgN&&... argn)
+{
+    stream from{
+        std::forward<Arg1>(arg1),
+        std::forward<ArgN>(argn)...};
+    from.connect(to);
+    return from;
+}
+
+} // test
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/stream.ipp
+++ b/test/utils/impl/stream.ipp
@@ -1,0 +1,377 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_IMPL_STREAM_IPP
+#define BOOST_BEAST_TEST_IMPL_STREAM_IPP
+
+#include <boost/beast/_experimental/test/stream.hpp>
+#include <boost/beast/core/bind_handler.hpp>
+#include <boost/beast/core/buffer_traits.hpp>
+#include <boost/make_shared.hpp>
+#include <stdexcept>
+#include <vector>
+
+namespace boost {
+namespace beast {
+namespace test {
+
+//------------------------------------------------------------------------------
+
+stream::
+service::
+service(net::execution_context& ctx)
+    : beast::detail::service_base<service>(ctx)
+    , sp_(boost::make_shared<service_impl>())
+{
+}
+
+void
+stream::
+service::
+shutdown()
+{
+    std::vector<std::unique_ptr<read_op_base>> v;
+    std::lock_guard<std::mutex> g1(sp_->m_);
+    v.reserve(sp_->v_.size());
+    for(auto p : sp_->v_)
+    {
+        std::lock_guard<std::mutex> g2(p->m);
+        v.emplace_back(std::move(p->op));
+        p->code = status::eof;
+    }
+}
+
+auto
+stream::
+service::
+make_impl(
+    net::io_context& ctx,
+    test::fail_count* fc) ->
+    boost::shared_ptr<state>
+{
+    auto& svc = net::use_service<service>(ctx);
+    auto sp = boost::make_shared<state>(ctx, svc.sp_, fc);
+    std::lock_guard<std::mutex> g(svc.sp_->m_);
+    svc.sp_->v_.push_back(sp.get());
+    return sp;
+}
+
+void
+stream::
+service_impl::
+remove(state& impl)
+{
+    std::lock_guard<std::mutex> g(m_);
+    *std::find(
+        v_.begin(), v_.end(),
+            &impl) = std::move(v_.back());
+    v_.pop_back();
+}
+
+//------------------------------------------------------------------------------
+
+void stream::initiate_read(
+    boost::shared_ptr<state> const& in_,
+    std::unique_ptr<stream::read_op_base>&& op,
+    std::size_t buf_size)
+{
+    std::unique_lock<std::mutex> lock(in_->m);
+
+    ++in_->nread;
+    if(in_->op != nullptr)
+        BOOST_THROW_EXCEPTION(
+            std::logic_error{"in_->op != nullptr"});
+
+    // test failure
+    error_code ec;
+    if(in_->fc && in_->fc->fail(ec))
+    {
+        lock.unlock();
+        (*op)(ec);
+        return;
+    }
+
+    // A request to read 0 bytes from a stream is a no-op.
+    if(buf_size == 0 || buffer_bytes(in_->b.data()) > 0)
+    {
+        lock.unlock();
+        (*op)(ec);
+        return;
+    }
+
+    // deliver error
+    if(in_->code != status::ok)
+    {
+        lock.unlock();
+        (*op)(net::error::eof);
+        return;
+    }
+
+    // complete when bytes available or closed
+    in_->op = std::move(op);
+}
+
+stream::
+state::
+state(
+    net::io_context& ioc_,
+    boost::weak_ptr<service_impl> wp_,
+    fail_count* fc_)
+    : ioc(ioc_)
+    , wp(std::move(wp_))
+    , fc(fc_)
+{
+}
+
+stream::
+state::
+~state()
+{
+    // cancel outstanding read
+    if(op != nullptr)
+        (*op)(net::error::operation_aborted);
+}
+
+void
+stream::
+state::
+remove() noexcept
+{
+    auto sp = wp.lock();
+
+    // If this goes off, it means the lifetime of a test::stream object
+    // extended beyond the lifetime of the associated execution context.
+    BOOST_ASSERT(sp);
+
+    sp->remove(*this);
+}
+
+void
+stream::
+state::
+notify_read()
+{
+    if(op)
+    {
+        auto op_ = std::move(op);
+        op_->operator()(error_code{});
+    }
+    else
+    {
+        cv.notify_all();
+    }
+}
+
+void
+stream::
+state::
+cancel_read()
+{
+    std::unique_ptr<read_op_base> p;
+    {
+        std::lock_guard<std::mutex> lock(m);
+        code = status::eof;
+        p = std::move(op);
+    }
+    if(p != nullptr)
+        (*p)(net::error::operation_aborted);
+}
+
+//------------------------------------------------------------------------------
+
+stream::
+~stream()
+{
+    close();
+    in_->remove();
+}
+
+stream::
+stream(stream&& other)
+{
+    auto in = service::make_impl(
+        other.in_->ioc, other.in_->fc);
+    in_ = std::move(other.in_);
+    out_ = std::move(other.out_);
+    other.in_ = in;
+}
+
+stream&
+stream::
+operator=(stream&& other)
+{
+    close();
+    auto in = service::make_impl(
+        other.in_->ioc, other.in_->fc);
+    in_->remove();
+    in_ = std::move(other.in_);
+    out_ = std::move(other.out_);
+    other.in_ = in;
+    return *this;
+}
+
+//------------------------------------------------------------------------------
+
+stream::
+stream(net::io_context& ioc)
+    : in_(service::make_impl(ioc, nullptr))
+{
+}
+
+stream::
+stream(
+    net::io_context& ioc,
+    fail_count& fc)
+    : in_(service::make_impl(ioc, &fc))
+{
+}
+
+stream::
+stream(
+    net::io_context& ioc,
+    string_view s)
+    : in_(service::make_impl(ioc, nullptr))
+{
+    in_->b.commit(net::buffer_copy(
+        in_->b.prepare(s.size()),
+        net::buffer(s.data(), s.size())));
+}
+
+stream::
+stream(
+    net::io_context& ioc,
+    fail_count& fc,
+    string_view s)
+    : in_(service::make_impl(ioc, &fc))
+{
+    in_->b.commit(net::buffer_copy(
+        in_->b.prepare(s.size()),
+        net::buffer(s.data(), s.size())));
+}
+
+void
+stream::
+connect(stream& remote)
+{
+    BOOST_ASSERT(! out_.lock());
+    BOOST_ASSERT(! remote.out_.lock());
+    std::lock(in_->m, remote.in_->m);
+    std::lock_guard<std::mutex> guard1{in_->m, std::adopt_lock};
+    std::lock_guard<std::mutex> guard2{remote.in_->m, std::adopt_lock};
+    out_ = remote.in_;
+    remote.out_ = in_;
+    in_->code = status::ok;
+    remote.in_->code = status::ok;
+}
+
+string_view
+stream::
+str() const
+{
+    auto const bs = in_->b.data();
+    if(buffer_bytes(bs) == 0)
+        return {};
+    net::const_buffer const b = *net::buffer_sequence_begin(bs);
+    return {static_cast<char const*>(b.data()), b.size()};
+}
+
+void
+stream::
+append(string_view s)
+{
+    std::lock_guard<std::mutex> lock{in_->m};
+    in_->b.commit(net::buffer_copy(
+        in_->b.prepare(s.size()),
+        net::buffer(s.data(), s.size())));
+}
+
+void
+stream::
+clear()
+{
+    std::lock_guard<std::mutex> lock{in_->m};
+    in_->b.consume(in_->b.size());
+}
+
+void
+stream::
+close()
+{
+    in_->cancel_read();
+
+    // disconnect
+    {
+        auto out = out_.lock();
+        out_.reset();
+
+        // notify peer
+        if(out)
+        {
+            std::lock_guard<std::mutex> lock(out->m);
+            if(out->code == status::ok)
+            {
+                out->code = status::eof;
+                out->notify_read();
+            }
+        }
+    }
+}
+
+void
+stream::
+close_remote()
+{
+    std::lock_guard<std::mutex> lock{in_->m};
+    if(in_->code == status::ok)
+    {
+        in_->code = status::eof;
+        in_->notify_read();
+    }
+}
+
+void
+teardown(
+    role_type,
+    stream& s,
+    boost::system::error_code& ec)
+{
+    if( s.in_->fc &&
+        s.in_->fc->fail(ec))
+        return;
+
+    s.close();
+
+    if( s.in_->fc &&
+        s.in_->fc->fail(ec))
+        ec = net::error::eof;
+    else
+        ec = {};
+}
+
+//------------------------------------------------------------------------------
+
+stream
+connect(stream& to)
+{
+    stream from{to.get_executor().context()};
+    from.connect(to);
+    return from;
+}
+
+void
+connect(stream& s1, stream& s2)
+{
+    s1.connect(s2);
+}
+
+} // test
+} // beast
+} // boost
+
+#endif

--- a/test/utils/impl/string_view.hpp
+++ b/test/utils/impl/string_view.hpp
@@ -1,0 +1,1684 @@
+// Copyright 2017-2020 by Martin Moene
+//
+// string-view lite, a C++17-like string_view for C++98 and later.
+// For more information see https://github.com/martinmoene/string-view-lite
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#ifndef NONSTD_SV_LITE_H_INCLUDED
+#define NONSTD_SV_LITE_H_INCLUDED
+
+#define string_view_lite_MAJOR  1
+#define string_view_lite_MINOR  7
+#define string_view_lite_PATCH  0
+
+#define string_view_lite_VERSION  nssv_STRINGIFY(string_view_lite_MAJOR) "." nssv_STRINGIFY(string_view_lite_MINOR) "." nssv_STRINGIFY(string_view_lite_PATCH)
+
+#define nssv_STRINGIFY(  x )  nssv_STRINGIFY_( x )
+#define nssv_STRINGIFY_( x )  #x
+
+// string-view lite configuration:
+
+#define nssv_STRING_VIEW_DEFAULT  0
+#define nssv_STRING_VIEW_NONSTD   1
+#define nssv_STRING_VIEW_STD      2
+
+// tweak header support:
+
+#ifdef __has_include
+# if __has_include(<nonstd/string_view.tweak.hpp>)
+#  include <nonstd/string_view.tweak.hpp>
+# endif
+#define nssv_HAVE_TWEAK_HEADER  1
+#else
+#define nssv_HAVE_TWEAK_HEADER  0
+//# pragma message("string_view.hpp: Note: Tweak header not supported.")
+#endif
+
+// string_view selection and configuration:
+
+#if !defined( nssv_CONFIG_SELECT_STRING_VIEW )
+# define nssv_CONFIG_SELECT_STRING_VIEW  ( nssv_HAVE_STD_STRING_VIEW ? nssv_STRING_VIEW_STD : nssv_STRING_VIEW_NONSTD )
+#endif
+
+#ifndef  nssv_CONFIG_STD_SV_OPERATOR
+# define nssv_CONFIG_STD_SV_OPERATOR  0
+#endif
+
+#ifndef  nssv_CONFIG_USR_SV_OPERATOR
+# define nssv_CONFIG_USR_SV_OPERATOR  1
+#endif
+
+#ifdef   nssv_CONFIG_CONVERSION_STD_STRING
+# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS   nssv_CONFIG_CONVERSION_STD_STRING
+# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  nssv_CONFIG_CONVERSION_STD_STRING
+#endif
+
+#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+# define nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS  1
+#endif
+
+#ifndef  nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+# define nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS  1
+#endif
+
+#ifndef  nssv_CONFIG_NO_STREAM_INSERTION
+# define nssv_CONFIG_NO_STREAM_INSERTION  0
+#endif
+
+// Control presence of exception handling (try and auto discover):
+
+#ifndef nssv_CONFIG_NO_EXCEPTIONS
+# if defined(_MSC_VER)
+#  include <cstddef>    // for _HAS_EXCEPTIONS
+# endif
+# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (_HAS_EXCEPTIONS)
+#  define nssv_CONFIG_NO_EXCEPTIONS  0
+# else
+#  define nssv_CONFIG_NO_EXCEPTIONS  1
+# endif
+#endif
+
+// C++ language version detection (C++23 is speculative):
+// Note: VC14.0/1900 (VS2015) lacks too much from C++14.
+
+#ifndef   nssv_CPLUSPLUS
+# if defined(_MSVC_LANG ) && !defined(__clang__)
+#  define nssv_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define nssv_CPLUSPLUS  __cplusplus
+# endif
+#endif
+
+#define nssv_CPP98_OR_GREATER  ( nssv_CPLUSPLUS >= 199711L )
+#define nssv_CPP11_OR_GREATER  ( nssv_CPLUSPLUS >= 201103L )
+#define nssv_CPP11_OR_GREATER_ ( nssv_CPLUSPLUS >= 201103L )
+#define nssv_CPP14_OR_GREATER  ( nssv_CPLUSPLUS >= 201402L )
+#define nssv_CPP17_OR_GREATER  ( nssv_CPLUSPLUS >= 201703L )
+#define nssv_CPP20_OR_GREATER  ( nssv_CPLUSPLUS >= 202002L )
+#define nssv_CPP23_OR_GREATER  ( nssv_CPLUSPLUS >= 202300L )
+
+// use C++17 std::string_view if available and requested:
+
+#if nssv_CPP17_OR_GREATER && defined(__has_include )
+# if __has_include( <string_view> )
+#  define nssv_HAVE_STD_STRING_VIEW  1
+# else
+#  define nssv_HAVE_STD_STRING_VIEW  0
+# endif
+#else
+# define  nssv_HAVE_STD_STRING_VIEW  0
+#endif
+
+#define  nssv_USES_STD_STRING_VIEW  ( (nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_STD) || ((nssv_CONFIG_SELECT_STRING_VIEW == nssv_STRING_VIEW_DEFAULT) && nssv_HAVE_STD_STRING_VIEW) )
+
+#define nssv_HAVE_STARTS_WITH ( nssv_CPP20_OR_GREATER || !nssv_USES_STD_STRING_VIEW )
+#define nssv_HAVE_ENDS_WITH     nssv_HAVE_STARTS_WITH
+
+//
+// Use C++17 std::string_view:
+//
+
+#if nssv_USES_STD_STRING_VIEW
+
+#include <string_view>
+
+// Extensions for std::string:
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+
+template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
+std::basic_string<CharT, Traits, Allocator>
+to_string( std::basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
+{
+    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string_view<CharT, Traits>
+to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
+{
+    return std::basic_string_view<CharT, Traits>( s.data(), s.size() );
+}
+
+// Literal operators sv and _sv:
+
+#if nssv_CONFIG_STD_SV_OPERATOR
+
+using namespace std::literals::string_view_literals;
+
+#endif
+
+#if nssv_CONFIG_USR_SV_OPERATOR
+
+inline namespace literals {
+inline namespace string_view_literals {
+
+
+constexpr std::string_view operator "" _sv( const char* str, size_t len ) noexcept  // (1)
+{
+    return std::string_view{ str, len };
+}
+
+constexpr std::u16string_view operator "" _sv( const char16_t* str, size_t len ) noexcept  // (2)
+{
+    return std::u16string_view{ str, len };
+}
+
+constexpr std::u32string_view operator "" _sv( const char32_t* str, size_t len ) noexcept  // (3)
+{
+    return std::u32string_view{ str, len };
+}
+
+constexpr std::wstring_view operator "" _sv( const wchar_t* str, size_t len ) noexcept  // (4)
+{
+    return std::wstring_view{ str, len };
+}
+
+}} // namespace literals::string_view_literals
+
+#endif // nssv_CONFIG_USR_SV_OPERATOR
+
+} // namespace nonstd
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+
+using std::string_view;
+using std::wstring_view;
+using std::u16string_view;
+using std::u32string_view;
+using std::basic_string_view;
+
+// literal "sv" and "_sv", see above
+
+using std::operator==;
+using std::operator!=;
+using std::operator<;
+using std::operator<=;
+using std::operator>;
+using std::operator>=;
+
+using std::operator<<;
+
+} // namespace nonstd
+
+#else // nssv_HAVE_STD_STRING_VIEW
+
+//
+// Before C++17: use string_view lite:
+//
+
+// Compiler versions:
+//
+// MSVC++  6.0  _MSC_VER == 1200  nssv_COMPILER_MSVC_VERSION ==  60  (Visual Studio 6.0)
+// MSVC++  7.0  _MSC_VER == 1300  nssv_COMPILER_MSVC_VERSION ==  70  (Visual Studio .NET 2002)
+// MSVC++  7.1  _MSC_VER == 1310  nssv_COMPILER_MSVC_VERSION ==  71  (Visual Studio .NET 2003)
+// MSVC++  8.0  _MSC_VER == 1400  nssv_COMPILER_MSVC_VERSION ==  80  (Visual Studio 2005)
+// MSVC++  9.0  _MSC_VER == 1500  nssv_COMPILER_MSVC_VERSION ==  90  (Visual Studio 2008)
+// MSVC++ 10.0  _MSC_VER == 1600  nssv_COMPILER_MSVC_VERSION == 100  (Visual Studio 2010)
+// MSVC++ 11.0  _MSC_VER == 1700  nssv_COMPILER_MSVC_VERSION == 110  (Visual Studio 2012)
+// MSVC++ 12.0  _MSC_VER == 1800  nssv_COMPILER_MSVC_VERSION == 120  (Visual Studio 2013)
+// MSVC++ 14.0  _MSC_VER == 1900  nssv_COMPILER_MSVC_VERSION == 140  (Visual Studio 2015)
+// MSVC++ 14.1  _MSC_VER >= 1910  nssv_COMPILER_MSVC_VERSION == 141  (Visual Studio 2017)
+// MSVC++ 14.2  _MSC_VER >= 1920  nssv_COMPILER_MSVC_VERSION == 142  (Visual Studio 2019)
+
+#if defined(_MSC_VER ) && !defined(__clang__)
+# define nssv_COMPILER_MSVC_VER      (_MSC_VER )
+# define nssv_COMPILER_MSVC_VERSION  (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+#else
+# define nssv_COMPILER_MSVC_VER      0
+# define nssv_COMPILER_MSVC_VERSION  0
+#endif
+
+#define nssv_COMPILER_VERSION( major, minor, patch )  ( 10 * ( 10 * (major) + (minor) ) + (patch) )
+
+#if defined( __apple_build_version__ )
+# define nssv_COMPILER_APPLECLANG_VERSION  nssv_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+# define nssv_COMPILER_CLANG_VERSION       0
+#elif defined( __clang__ )
+# define nssv_COMPILER_APPLECLANG_VERSION  0
+# define nssv_COMPILER_CLANG_VERSION       nssv_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#else
+# define nssv_COMPILER_APPLECLANG_VERSION  0
+# define nssv_COMPILER_CLANG_VERSION       0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define nssv_COMPILER_GNUC_VERSION  nssv_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#else
+# define nssv_COMPILER_GNUC_VERSION  0
+#endif
+
+// half-open range [lo..hi):
+#define nssv_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+
+// Presence of language and library features:
+
+#ifdef _HAS_CPP0X
+# define nssv_HAS_CPP0X  _HAS_CPP0X
+#else
+# define nssv_HAS_CPP0X  0
+#endif
+
+// Unless defined otherwise below, consider VC14 as C++11 for variant-lite:
+
+#if nssv_COMPILER_MSVC_VER >= 1900
+# undef  nssv_CPP11_OR_GREATER
+# define nssv_CPP11_OR_GREATER  1
+#endif
+
+#define nssv_CPP11_90   (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1500)
+#define nssv_CPP11_100  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1600)
+#define nssv_CPP11_110  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1700)
+#define nssv_CPP11_120  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1800)
+#define nssv_CPP11_140  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1900)
+#define nssv_CPP11_141  (nssv_CPP11_OR_GREATER_ || nssv_COMPILER_MSVC_VER >= 1910)
+
+#define nssv_CPP14_000  (nssv_CPP14_OR_GREATER)
+#define nssv_CPP17_000  (nssv_CPP17_OR_GREATER)
+
+// Presence of C++11 language features:
+
+#define nssv_HAVE_CONSTEXPR_11          nssv_CPP11_140
+#define nssv_HAVE_EXPLICIT_CONVERSION   nssv_CPP11_140
+#define nssv_HAVE_INLINE_NAMESPACE      nssv_CPP11_140
+#define nssv_HAVE_IS_DEFAULT            nssv_CPP11_140
+#define nssv_HAVE_IS_DELETE             nssv_CPP11_140
+#define nssv_HAVE_NOEXCEPT              nssv_CPP11_140
+#define nssv_HAVE_NULLPTR               nssv_CPP11_100
+#define nssv_HAVE_REF_QUALIFIER         nssv_CPP11_140
+#define nssv_HAVE_UNICODE_LITERALS      nssv_CPP11_140
+#define nssv_HAVE_USER_DEFINED_LITERALS nssv_CPP11_140
+#define nssv_HAVE_WCHAR16_T             nssv_CPP11_100
+#define nssv_HAVE_WCHAR32_T             nssv_CPP11_100
+
+#if ! ( ( nssv_CPP11_OR_GREATER && nssv_COMPILER_CLANG_VERSION ) || nssv_BETWEEN( nssv_COMPILER_CLANG_VERSION, 300, 400 ) )
+# define nssv_HAVE_STD_DEFINED_LITERALS  nssv_CPP11_140
+#else
+# define nssv_HAVE_STD_DEFINED_LITERALS  0
+#endif
+
+// Presence of C++14 language features:
+
+#define nssv_HAVE_CONSTEXPR_14          nssv_CPP14_000
+
+// Presence of C++17 language features:
+
+#define nssv_HAVE_NODISCARD             nssv_CPP17_000
+
+// Presence of C++ library features:
+
+#define nssv_HAVE_STD_HASH              nssv_CPP11_120
+
+// Presence of compiler intrinsics:
+
+// Providing char-type specializations for compare() and length() that
+// use compiler intrinsics can improve compile- and run-time performance.
+//
+// The challenge is in using the right combinations of builtin availability
+// and its constexpr-ness.
+//
+// | compiler | __builtin_memcmp (constexpr) | memcmp  (constexpr) |
+// |----------|------------------------------|---------------------|
+// | clang    | 4.0              (>= 4.0   ) | any     (?        ) |
+// | clang-a  | 9.0              (>= 9.0   ) | any     (?        ) |
+// | gcc      | any              (constexpr) | any     (?        ) |
+// | msvc     | >= 14.2 C++17    (>= 14.2  ) | any     (?        ) |
+
+#define nssv_HAVE_BUILTIN_VER     ( (nssv_CPP17_000 && nssv_COMPILER_MSVC_VERSION >= 142) || nssv_COMPILER_GNUC_VERSION > 0 || nssv_COMPILER_CLANG_VERSION >= 400 || nssv_COMPILER_APPLECLANG_VERSION >= 900 )
+#define nssv_HAVE_BUILTIN_CE      (  nssv_HAVE_BUILTIN_VER )
+
+#define nssv_HAVE_BUILTIN_MEMCMP  ( (nssv_HAVE_CONSTEXPR_14 && nssv_HAVE_BUILTIN_CE) || !nssv_HAVE_CONSTEXPR_14 )
+#define nssv_HAVE_BUILTIN_STRLEN  ( (nssv_HAVE_CONSTEXPR_11 && nssv_HAVE_BUILTIN_CE) || !nssv_HAVE_CONSTEXPR_11 )
+
+#ifdef __has_builtin
+# define nssv_HAVE_BUILTIN( x )  __has_builtin( x )
+#else
+# define nssv_HAVE_BUILTIN( x )  0
+#endif
+
+#if nssv_HAVE_BUILTIN(__builtin_memcmp) || nssv_HAVE_BUILTIN_VER
+# define nssv_BUILTIN_MEMCMP  __builtin_memcmp
+#else
+# define nssv_BUILTIN_MEMCMP  memcmp
+#endif
+
+#if nssv_HAVE_BUILTIN(__builtin_strlen) || nssv_HAVE_BUILTIN_VER
+# define nssv_BUILTIN_STRLEN  __builtin_strlen
+#else
+# define nssv_BUILTIN_STRLEN  strlen
+#endif
+
+// C++ feature usage:
+
+#if nssv_HAVE_CONSTEXPR_11
+# define nssv_constexpr  constexpr
+#else
+# define nssv_constexpr  /*constexpr*/
+#endif
+
+#if  nssv_HAVE_CONSTEXPR_14
+# define nssv_constexpr14  constexpr
+#else
+# define nssv_constexpr14  /*constexpr*/
+#endif
+
+#if nssv_HAVE_EXPLICIT_CONVERSION
+# define nssv_explicit  explicit
+#else
+# define nssv_explicit  /*explicit*/
+#endif
+
+#if nssv_HAVE_INLINE_NAMESPACE
+# define nssv_inline_ns  inline
+#else
+# define nssv_inline_ns  /*inline*/
+#endif
+
+#if nssv_HAVE_NOEXCEPT
+# define nssv_noexcept  noexcept
+#else
+# define nssv_noexcept  /*noexcept*/
+#endif
+
+//#if nssv_HAVE_REF_QUALIFIER
+//# define nssv_ref_qual  &
+//# define nssv_refref_qual  &&
+//#else
+//# define nssv_ref_qual  /*&*/
+//# define nssv_refref_qual  /*&&*/
+//#endif
+
+#if nssv_HAVE_NULLPTR
+# define nssv_nullptr  nullptr
+#else
+# define nssv_nullptr  NULL
+#endif
+
+#if nssv_HAVE_NODISCARD
+# define nssv_nodiscard  [[nodiscard]]
+#else
+# define nssv_nodiscard  /*[[nodiscard]]*/
+#endif
+
+// Additional includes:
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <limits>
+#include <string>   // std::char_traits<>
+
+#if ! nssv_CONFIG_NO_STREAM_INSERTION
+# include <ostream>
+#endif
+
+#if ! nssv_CONFIG_NO_EXCEPTIONS
+# include <stdexcept>
+#endif
+
+#if nssv_CPP11_OR_GREATER
+# include <type_traits>
+#endif
+
+// Clang, GNUC, MSVC warning suppression macros:
+
+#if defined(__clang__)
+# pragma clang diagnostic ignored "-Wreserved-user-defined-literal"
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wuser-defined-literals"
+#elif nssv_COMPILER_GNUC_VERSION >= 480
+#  pragma  GCC  diagnostic push
+#  pragma  GCC  diagnostic ignored "-Wliteral-suffix"
+#endif // __clang__
+
+#if nssv_COMPILER_MSVC_VERSION >= 140
+# define nssv_SUPPRESS_MSGSL_WARNING(expr)        [[gsl::suppress(expr)]]
+# define nssv_SUPPRESS_MSVC_WARNING(code, descr)  __pragma(warning(suppress: code) )
+# define nssv_DISABLE_MSVC_WARNINGS(codes)        __pragma(warning(push))  __pragma(warning(disable: codes))
+#else
+# define nssv_SUPPRESS_MSGSL_WARNING(expr)
+# define nssv_SUPPRESS_MSVC_WARNING(code, descr)
+# define nssv_DISABLE_MSVC_WARNINGS(codes)
+#endif
+
+#if defined(__clang__)
+# define nssv_RESTORE_WARNINGS()  _Pragma("clang diagnostic pop")
+#elif nssv_COMPILER_GNUC_VERSION >= 480
+#  define nssv_RESTORE_WARNINGS()  _Pragma("GCC diagnostic pop")
+#elif nssv_COMPILER_MSVC_VERSION >= 140
+# define nssv_RESTORE_WARNINGS()  __pragma(warning(pop ))
+#else
+# define nssv_RESTORE_WARNINGS()
+#endif
+
+// Suppress the following MSVC (GSL) warnings:
+// - C4455, non-gsl   : 'operator ""sv': literal suffix identifiers that do not
+//                      start with an underscore are reserved
+// - C26472, gsl::t.1 : don't use a static_cast for arithmetic conversions;
+//                      use brace initialization, gsl::narrow_cast or gsl::narow
+// - C26481: gsl::b.1 : don't use pointer arithmetic. Use span instead
+
+nssv_DISABLE_MSVC_WARNINGS( 4455 26481 26472 )
+//nssv_DISABLE_CLANG_WARNINGS( "-Wuser-defined-literals" )
+//nssv_DISABLE_GNUC_WARNINGS( -Wliteral-suffix )
+
+namespace nonstd { namespace sv_lite {
+
+//
+// basic_string_view declaration:
+//
+
+template
+<
+    class CharT,
+    class Traits = std::char_traits<CharT>
+>
+class basic_string_view;
+
+namespace detail {
+
+// support constexpr comparison in C++14;
+// for C++17 and later, use provided traits:
+
+template< typename CharT >
+inline nssv_constexpr14 int compare( CharT const * s1, CharT const * s2, std::size_t count )
+{
+    while ( count-- != 0 )
+    {
+        if ( *s1 < *s2 ) return -1;
+        if ( *s1 > *s2 ) return +1;
+        ++s1; ++s2;
+    }
+    return 0;
+}
+
+#if nssv_HAVE_BUILTIN_MEMCMP
+
+// specialization of compare() for char, see also generic compare() above:
+
+inline nssv_constexpr14 int compare( char const * s1, char const * s2, std::size_t count )
+{
+    return nssv_BUILTIN_MEMCMP( s1, s2, count );
+}
+
+#endif
+
+#if nssv_HAVE_BUILTIN_STRLEN
+
+// specialization of length() for char, see also generic length() further below:
+
+inline nssv_constexpr std::size_t length( char const * s )
+{
+    return nssv_BUILTIN_STRLEN( s );
+}
+
+#endif
+
+#if defined(__OPTIMIZE__)
+
+// gcc, clang provide __OPTIMIZE__
+// Expect tail call optimization to make length() non-recursive:
+
+template< typename CharT >
+inline nssv_constexpr std::size_t length( CharT * s, std::size_t result = 0 )
+{
+    return *s == '\0' ? result : length( s + 1, result + 1 );
+}
+
+#else // OPTIMIZE
+
+// non-recursive:
+
+template< typename CharT >
+inline nssv_constexpr14 std::size_t length( CharT * s )
+{
+    std::size_t result = 0;
+    while ( *s++ != '\0' )
+    {
+       ++result;
+    }
+    return result;
+}
+
+#endif // OPTIMIZE
+
+#if nssv_CPP11_OR_GREATER && ! nssv_CPP17_OR_GREATER
+#if defined(__OPTIMIZE__)
+
+// gcc, clang provide __OPTIMIZE__
+// Expect tail call optimization to make search() non-recursive:
+
+template< class CharT, class Traits = std::char_traits<CharT> >
+constexpr const CharT* search( basic_string_view<CharT, Traits> haystack, basic_string_view<CharT, Traits> needle )
+{
+    return haystack.starts_with( needle ) ? haystack.begin() :
+        haystack.empty() ? haystack.end() : search( haystack.substr(1), needle );
+}
+
+#else // OPTIMIZE
+
+// non-recursive:
+
+template< class CharT, class Traits = std::char_traits<CharT> >
+constexpr const CharT* search( basic_string_view<CharT, Traits> haystack, basic_string_view<CharT, Traits> needle )
+{
+    return std::search( haystack.begin(), haystack.end(), needle.begin(), needle.end() );
+}
+
+#endif // OPTIMIZE
+#endif // nssv_CPP11_OR_GREATER && ! nssv_CPP17_OR_GREATER
+
+} // namespace detail
+
+//
+// basic_string_view:
+//
+
+template
+<
+    class CharT,
+    class Traits /* = std::char_traits<CharT> */
+>
+class basic_string_view
+{
+public:
+    // Member types:
+
+    typedef Traits traits_type;
+    typedef CharT  value_type;
+
+    typedef CharT       * pointer;
+    typedef CharT const * const_pointer;
+    typedef CharT       & reference;
+    typedef CharT const & const_reference;
+
+    typedef const_pointer iterator;
+    typedef const_pointer const_iterator;
+    typedef std::reverse_iterator< const_iterator > reverse_iterator;
+    typedef std::reverse_iterator< const_iterator > const_reverse_iterator;
+
+    typedef std::size_t     size_type;
+    typedef std::ptrdiff_t  difference_type;
+
+    // 24.4.2.1 Construction and assignment:
+
+    nssv_constexpr basic_string_view() nssv_noexcept
+        : data_( nssv_nullptr )
+        , size_( 0 )
+    {}
+
+#if nssv_CPP11_OR_GREATER
+    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept = default;
+#else
+    nssv_constexpr basic_string_view( basic_string_view const & other ) nssv_noexcept
+        : data_( other.data_)
+        , size_( other.size_)
+    {}
+#endif
+
+    nssv_constexpr basic_string_view( CharT const * s, size_type count ) nssv_noexcept // non-standard noexcept
+        : data_( s )
+        , size_( count )
+    {}
+
+    nssv_constexpr basic_string_view( CharT const * s) nssv_noexcept // non-standard noexcept
+        : data_( s )
+#if nssv_CPP17_OR_GREATER
+        , size_( Traits::length(s) )
+#elif nssv_CPP11_OR_GREATER
+        , size_( detail::length(s) )
+#else
+        , size_( Traits::length(s) )
+#endif
+    {}
+
+#if  nssv_HAVE_NULLPTR
+# if nssv_HAVE_IS_DELETE
+    nssv_constexpr basic_string_view( std::nullptr_t ) nssv_noexcept = delete;
+# else
+    private: nssv_constexpr basic_string_view( std::nullptr_t ) nssv_noexcept; public:
+# endif
+#endif
+
+    // Assignment:
+
+#if nssv_CPP11_OR_GREATER
+    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept = default;
+#else
+    nssv_constexpr14 basic_string_view & operator=( basic_string_view const & other ) nssv_noexcept
+    {
+        data_ = other.data_;
+        size_ = other.size_;
+        return *this;
+    }
+#endif
+
+    // 24.4.2.2 Iterator support:
+
+    nssv_constexpr const_iterator begin()  const nssv_noexcept { return data_;         }
+    nssv_constexpr const_iterator end()    const nssv_noexcept { return data_ + size_; }
+
+    nssv_constexpr const_iterator cbegin() const nssv_noexcept { return begin(); }
+    nssv_constexpr const_iterator cend()   const nssv_noexcept { return end();   }
+
+    nssv_constexpr const_reverse_iterator rbegin()  const nssv_noexcept { return const_reverse_iterator( end() );   }
+    nssv_constexpr const_reverse_iterator rend()    const nssv_noexcept { return const_reverse_iterator( begin() ); }
+
+    nssv_constexpr const_reverse_iterator crbegin() const nssv_noexcept { return rbegin(); }
+    nssv_constexpr const_reverse_iterator crend()   const nssv_noexcept { return rend();   }
+
+    // 24.4.2.3 Capacity:
+
+    nssv_constexpr size_type size()     const nssv_noexcept { return size_; }
+    nssv_constexpr size_type length()   const nssv_noexcept { return size_; }
+    nssv_constexpr size_type max_size() const nssv_noexcept { return (std::numeric_limits< size_type >::max)(); }
+
+    // since C++20
+    nssv_nodiscard nssv_constexpr bool empty() const nssv_noexcept
+    {
+        return 0 == size_;
+    }
+
+    // 24.4.2.4 Element access:
+
+    nssv_constexpr const_reference operator[]( size_type pos ) const
+    {
+        return data_at( pos );
+    }
+
+    nssv_constexpr14 const_reference at( size_type pos ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos < size() );
+#else
+        if ( pos >= size() )
+        {
+            throw std::out_of_range("nonstd::string_view::at()");
+        }
+#endif
+        return data_at( pos );
+    }
+
+    nssv_constexpr const_reference front() const { return data_at( 0 );          }
+    nssv_constexpr const_reference back()  const { return data_at( size() - 1 ); }
+
+    nssv_constexpr const_pointer   data()  const nssv_noexcept { return data_; }
+
+    // 24.4.2.5 Modifiers:
+
+    nssv_constexpr14 void remove_prefix( size_type n )
+    {
+        assert( n <= size() );
+        data_ += n;
+        size_ -= n;
+    }
+
+    nssv_constexpr14 void remove_suffix( size_type n )
+    {
+        assert( n <= size() );
+        size_ -= n;
+    }
+
+    nssv_constexpr14 void swap( basic_string_view & other ) nssv_noexcept
+    {
+        const basic_string_view tmp(other);
+        other = *this;
+        *this = tmp;
+    }
+
+    // 24.4.2.6 String operations:
+
+    size_type copy( CharT * dest, size_type n, size_type pos = 0 ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos <= size() );
+#else
+        if ( pos > size() )
+        {
+            throw std::out_of_range("nonstd::string_view::copy()");
+        }
+#endif
+        const size_type rlen = (std::min)( n, size() - pos );
+
+        (void) Traits::copy( dest, data() + pos, rlen );
+
+        return rlen;
+    }
+
+    nssv_constexpr14 basic_string_view substr( size_type pos = 0, size_type n = npos ) const
+    {
+#if nssv_CONFIG_NO_EXCEPTIONS
+        assert( pos <= size() );
+#else
+        if ( pos > size() )
+        {
+            throw std::out_of_range("nonstd::string_view::substr()");
+        }
+#endif
+        return basic_string_view( data() + pos, (std::min)( n, size() - pos ) );
+    }
+
+    // compare(), 6x:
+
+    nssv_constexpr14 int compare( basic_string_view other ) const nssv_noexcept // (1)
+    {
+#if nssv_CPP17_OR_GREATER
+        if ( const int result = Traits::compare( data(), other.data(), (std::min)( size(), other.size() ) ) )
+#else
+        if ( const int result = detail::compare( data(), other.data(), (std::min)( size(), other.size() ) ) )
+#endif
+        {
+            return result;
+        }
+
+        return size() == other.size() ? 0 : size() < other.size() ? -1 : 1;
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other ) const // (2)
+    {
+        return substr( pos1, n1 ).compare( other );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, basic_string_view other, size_type pos2, size_type n2 ) const // (3)
+    {
+        return substr( pos1, n1 ).compare( other.substr( pos2, n2 ) );
+    }
+
+    nssv_constexpr int compare( CharT const * s ) const // (4)
+    {
+        return compare( basic_string_view( s ) );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s ) const // (5)
+    {
+        return substr( pos1, n1 ).compare( basic_string_view( s ) );
+    }
+
+    nssv_constexpr int compare( size_type pos1, size_type n1, CharT const * s, size_type n2 ) const // (6)
+    {
+        return substr( pos1, n1 ).compare( basic_string_view( s, n2 ) );
+    }
+
+    // 24.4.2.7 Searching:
+
+    // starts_with(), 3x, since C++20:
+
+    nssv_constexpr bool starts_with( basic_string_view v ) const nssv_noexcept  // (1)
+    {
+        return size() >= v.size() && compare( 0, v.size(), v ) == 0;
+    }
+
+    nssv_constexpr bool starts_with( CharT c ) const nssv_noexcept  // (2)
+    {
+        return starts_with( basic_string_view( &c, 1 ) );
+    }
+
+    nssv_constexpr bool starts_with( CharT const * s ) const  // (3)
+    {
+        return starts_with( basic_string_view( s ) );
+    }
+
+    // ends_with(), 3x, since C++20:
+
+    nssv_constexpr bool ends_with( basic_string_view v ) const nssv_noexcept  // (1)
+    {
+        return size() >= v.size() && compare( size() - v.size(), npos, v ) == 0;
+    }
+
+    nssv_constexpr bool ends_with( CharT c ) const nssv_noexcept  // (2)
+    {
+        return ends_with( basic_string_view( &c, 1 ) );
+    }
+
+    nssv_constexpr bool ends_with( CharT const * s ) const  // (3)
+    {
+        return ends_with( basic_string_view( s ) );
+    }
+
+    // find(), 4x:
+
+    nssv_constexpr14 size_type find( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return assert( v.size() == 0 || v.data() != nssv_nullptr )
+            , pos >= size()
+            ? npos : to_pos(
+#if nssv_CPP11_OR_GREATER && ! nssv_CPP17_OR_GREATER
+                detail::search( substr(pos), v )
+#else
+                std::search( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq )
+#endif
+            );
+    }
+
+    nssv_constexpr size_type find( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return find( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr size_type find( CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find( basic_string_view( s ), pos );
+    }
+
+    // rfind(), 4x:
+
+    nssv_constexpr14 size_type rfind( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        if ( size() < v.size() )
+        {
+            return npos;
+        }
+
+        if ( v.empty() )
+        {
+            return (std::min)( size(), pos );
+        }
+
+        const_iterator last   = cbegin() + (std::min)( size() - v.size(), pos ) + v.size();
+        const_iterator result = std::find_end( cbegin(), last, v.cbegin(), v.cend(), Traits::eq );
+
+        return result != last ? size_type( result - cbegin() ) : npos;
+    }
+
+    nssv_constexpr14 size_type rfind( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return rfind( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return rfind( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr14 size_type rfind( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return rfind( basic_string_view( s ), pos );
+    }
+
+    // find_first_of(), 4x:
+
+    nssv_constexpr size_type find_first_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return pos >= size()
+            ? npos
+            : to_pos( std::find_first_of( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    nssv_constexpr size_type find_first_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find_first_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_first_of( CharT const * s, size_type pos, size_type n ) const  // (3)
+    {
+        return find_first_of( basic_string_view( s, n ), pos );
+    }
+
+    nssv_constexpr size_type find_first_of(  CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find_first_of( basic_string_view( s ), pos );
+    }
+
+    // find_last_of(), 4x:
+
+    nssv_constexpr size_type find_last_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        return empty()
+            ? npos
+            : pos >= size()
+            ? find_last_of( v, size() - 1 )
+            : to_pos( std::find_first_of( const_reverse_iterator( cbegin() + pos + 1 ), crend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return find_last_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_last_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_last_of( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return find_last_of( basic_string_view( s ), pos );
+    }
+
+    // find_first_not_of(), 4x:
+
+    nssv_constexpr size_type find_first_not_of( basic_string_view v, size_type pos = 0 ) const nssv_noexcept  // (1)
+    {
+        return pos >= size()
+            ? npos
+            : to_pos( std::find_if( cbegin() + pos, cend(), not_in_view( v ) ) );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT c, size_type pos = 0 ) const nssv_noexcept  // (2)
+    {
+        return find_first_not_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_first_not_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_first_not_of( CharT const * s, size_type pos = 0 ) const  // (4)
+    {
+        return find_first_not_of( basic_string_view( s ), pos );
+    }
+
+    // find_last_not_of(), 4x:
+
+    nssv_constexpr size_type find_last_not_of( basic_string_view v, size_type pos = npos ) const nssv_noexcept  // (1)
+    {
+        return empty()
+            ? npos
+            : pos >= size()
+            ? find_last_not_of( v, size() - 1 )
+            : to_pos( std::find_if( const_reverse_iterator( cbegin() + pos + 1 ), crend(), not_in_view( v ) ) );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT c, size_type pos = npos ) const nssv_noexcept  // (2)
+    {
+        return find_last_not_of( basic_string_view( &c, 1 ), pos );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos, size_type count ) const  // (3)
+    {
+        return find_last_not_of( basic_string_view( s, count ), pos );
+    }
+
+    nssv_constexpr size_type find_last_not_of( CharT const * s, size_type pos = npos ) const  // (4)
+    {
+        return find_last_not_of( basic_string_view( s ), pos );
+    }
+
+    // Constants:
+
+#if nssv_CPP17_OR_GREATER
+    static nssv_constexpr size_type npos = size_type(-1);
+#elif nssv_CPP11_OR_GREATER
+    enum : size_type { npos = size_type(-1) };
+#else
+    enum { npos = size_type(-1) };
+#endif
+
+private:
+    struct not_in_view
+    {
+        const basic_string_view v;
+
+        nssv_constexpr explicit not_in_view( basic_string_view v_ ) : v( v_ ) {}
+
+        nssv_constexpr bool operator()( CharT c ) const
+        {
+            return npos == v.find_first_of( c );
+        }
+    };
+
+    nssv_constexpr size_type to_pos( const_iterator it ) const
+    {
+        return it == cend() ? npos : size_type( it - cbegin() );
+    }
+
+    nssv_constexpr size_type to_pos( const_reverse_iterator it ) const
+    {
+        return it == crend() ? npos : size_type( crend() - it - 1 );
+    }
+
+    nssv_constexpr const_reference data_at( size_type pos ) const
+    {
+#if nssv_BETWEEN( nssv_COMPILER_GNUC_VERSION, 1, 500 )
+        return data_[pos];
+#else
+        return assert( pos < size() ), data_[pos];
+#endif
+    }
+
+private:
+    const_pointer data_;
+    size_type     size_;
+
+public:
+#if nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+
+    template< class Allocator >
+    basic_string_view( std::basic_string<CharT, Traits, Allocator> const & s ) nssv_noexcept
+        : data_( s.data() )
+        , size_( s.size() )
+    {}
+
+#if nssv_HAVE_EXPLICIT_CONVERSION
+
+    template< class Allocator >
+    explicit operator std::basic_string<CharT, Traits, Allocator>() const
+    {
+        return to_string( Allocator() );
+    }
+
+#endif // nssv_HAVE_EXPLICIT_CONVERSION
+
+#if nssv_CPP11_OR_GREATER
+
+    template< class Allocator = std::allocator<CharT> >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a = Allocator() ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#else
+
+    std::basic_string<CharT, Traits>
+    to_string() const
+    {
+        return std::basic_string<CharT, Traits>( begin(), end() );
+    }
+
+    template< class Allocator >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#endif // nssv_CPP11_OR_GREATER
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_CLASS_METHODS
+};
+
+//
+// Non-member functions:
+//
+
+// 24.4.3 Non-member comparison functions:
+// lexicographically compare two string views (function template):
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator== (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator!= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator< (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator<= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator> (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0; }
+
+template< class CharT, class Traits >
+nssv_constexpr bool operator>= (
+    basic_string_view <CharT, Traits> lhs,
+    basic_string_view <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0; }
+
+// Let S be basic_string_view<CharT, Traits>, and sv be an instance of S.
+// Implementations shall provide sufficient additional overloads marked
+// constexpr and noexcept so that an object t with an implicit conversion
+// to S can be compared according to Table 67.
+
+#if ! nssv_CPP11_OR_GREATER || nssv_BETWEEN( nssv_COMPILER_MSVC_VERSION, 100, 141 )
+
+// accommodate for older compilers:
+
+// ==
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator==(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return lhs.size() == detail::length( rhs ) && lhs.compare( rhs ) == 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator==(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return detail::length( lhs ) == rhs.size() && rhs.compare( lhs ) == 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator==(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator==(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+// !=
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator!=(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator!=(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator!=(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator!=(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+// <
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return rhs.compare( lhs ) > 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return rhs.compare( lhs ) > 0; }
+
+// <=
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<=(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<=(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return rhs.compare( lhs ) >= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<=(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator<=(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return rhs.compare( lhs ) >= 0; }
+
+// >
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return rhs.compare( lhs ) < 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return rhs.compare( lhs ) < 0; }
+
+// >=
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>=(
+    basic_string_view<CharT, Traits> lhs,
+    CharT const * rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>=(
+    CharT const * lhs,
+    basic_string_view<CharT, Traits> rhs ) nssv_noexcept
+{ return rhs.compare( lhs ) <= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>=(
+    basic_string_view<CharT, Traits> lhs,
+    std::basic_string<CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0; }
+
+template< class CharT, class Traits>
+nssv_constexpr bool operator>=(
+    std::basic_string<CharT, Traits> rhs,
+    basic_string_view<CharT, Traits> lhs ) nssv_noexcept
+{ return rhs.compare( lhs ) <= 0; }
+
+#else // newer compilers:
+
+#define nssv_BASIC_STRING_VIEW_I(T,U)  typename std::decay< basic_string_view<T,U> >::type
+
+#if defined(_MSC_VER)       // issue 40
+# define nssv_MSVC_ORDER(x)  , int=x
+#else
+# define nssv_MSVC_ORDER(x)  /*, int=x*/
+#endif
+
+// ==
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator==(
+         basic_string_view  <CharT, Traits> lhs,
+    nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator==(
+    nssv_BASIC_STRING_VIEW_I(CharT, Traits) lhs,
+         basic_string_view  <CharT, Traits> rhs ) nssv_noexcept
+{ return lhs.size() == rhs.size() && lhs.compare( rhs ) == 0; }
+
+// !=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator!= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator!= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return !( lhs == rhs ); }
+
+// <
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator< (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator< (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) < 0; }
+
+// <=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator<= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator<= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) <= 0; }
+
+// >
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator> (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator> (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) > 0; }
+
+// >=
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(1) >
+nssv_constexpr bool operator>= (
+         basic_string_view  < CharT, Traits > lhs,
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0; }
+
+template< class CharT, class Traits  nssv_MSVC_ORDER(2) >
+nssv_constexpr bool operator>= (
+    nssv_BASIC_STRING_VIEW_I( CharT, Traits ) lhs,
+         basic_string_view  < CharT, Traits > rhs ) nssv_noexcept
+{ return lhs.compare( rhs ) >= 0; }
+
+#undef nssv_MSVC_ORDER
+#undef nssv_BASIC_STRING_VIEW_I
+
+#endif // compiler-dependent approach to comparisons
+
+// 24.4.4 Inserters and extractors:
+
+#if ! nssv_CONFIG_NO_STREAM_INSERTION
+
+namespace detail {
+
+template< class Stream >
+void write_padding( Stream & os, std::streamsize n )
+{
+    for ( std::streamsize i = 0; i < n; ++i )
+        os.rdbuf()->sputc( os.fill() );
+}
+
+template< class Stream, class View >
+Stream & write_to_stream( Stream & os, View const & sv )
+{
+    typename Stream::sentry sentry( os );
+
+    if ( !sentry )
+        return os;
+
+    const std::streamsize length = static_cast<std::streamsize>( sv.length() );
+
+    // Whether, and how, to pad:
+    const bool      pad = ( length < os.width() );
+    const bool left_pad = pad && ( os.flags() & std::ios_base::adjustfield ) == std::ios_base::right;
+
+    if ( left_pad )
+        write_padding( os, os.width() - length );
+
+    // Write span characters:
+    os.rdbuf()->sputn( sv.begin(), length );
+
+    if ( pad && !left_pad )
+        write_padding( os, os.width() - length );
+
+    // Reset output stream width:
+    os.width( 0 );
+
+    return os;
+}
+
+} // namespace detail
+
+template< class CharT, class Traits >
+std::basic_ostream<CharT, Traits> &
+operator<<(
+    std::basic_ostream<CharT, Traits>& os,
+    basic_string_view <CharT, Traits> sv )
+{
+    return detail::write_to_stream( os, sv );
+}
+
+#endif // nssv_CONFIG_NO_STREAM_INSERTION
+
+// Several typedefs for common character types are provided:
+
+typedef basic_string_view<char>      string_view;
+typedef basic_string_view<wchar_t>   wstring_view;
+#if nssv_HAVE_WCHAR16_T
+typedef basic_string_view<char16_t>  u16string_view;
+typedef basic_string_view<char32_t>  u32string_view;
+#endif
+
+}} // namespace nonstd::sv_lite
+
+//
+// 24.4.6 Suffix for basic_string_view literals:
+//
+
+#if nssv_HAVE_USER_DEFINED_LITERALS
+
+namespace nonstd {
+nssv_inline_ns namespace literals {
+nssv_inline_ns namespace string_view_literals {
+
+#if nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
+
+nssv_constexpr nonstd::sv_lite::string_view operator "" sv( const char* str, size_t len ) nssv_noexcept  // (1)
+{
+    return nonstd::sv_lite::string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u16string_view operator "" sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
+{
+    return nonstd::sv_lite::u16string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u32string_view operator "" sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
+{
+    return nonstd::sv_lite::u32string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::wstring_view operator "" sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
+{
+    return nonstd::sv_lite::wstring_view{ str, len };
+}
+
+#endif // nssv_CONFIG_STD_SV_OPERATOR && nssv_HAVE_STD_DEFINED_LITERALS
+
+#if nssv_CONFIG_USR_SV_OPERATOR
+
+nssv_constexpr nonstd::sv_lite::string_view operator "" _sv( const char* str, size_t len ) nssv_noexcept  // (1)
+{
+    return nonstd::sv_lite::string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u16string_view operator "" _sv( const char16_t* str, size_t len ) nssv_noexcept  // (2)
+{
+    return nonstd::sv_lite::u16string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::u32string_view operator "" _sv( const char32_t* str, size_t len ) nssv_noexcept  // (3)
+{
+    return nonstd::sv_lite::u32string_view{ str, len };
+}
+
+nssv_constexpr nonstd::sv_lite::wstring_view operator "" _sv( const wchar_t* str, size_t len ) nssv_noexcept  // (4)
+{
+    return nonstd::sv_lite::wstring_view{ str, len };
+}
+
+#endif // nssv_CONFIG_USR_SV_OPERATOR
+
+}}} // namespace nonstd::literals::string_view_literals
+
+#endif
+
+//
+// Extensions for std::string:
+//
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+namespace nonstd {
+namespace sv_lite {
+
+// Exclude MSVC 14 (19.00): it yields ambiguous to_string():
+
+#if nssv_CPP11_OR_GREATER && nssv_COMPILER_MSVC_VERSION != 140
+
+template< class CharT, class Traits, class Allocator = std::allocator<CharT> >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a = Allocator() )
+{
+    return std::basic_string<CharT,Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+#else
+
+template< class CharT, class Traits >
+std::basic_string<CharT, Traits>
+to_string( basic_string_view<CharT, Traits> v )
+{
+    return std::basic_string<CharT, Traits>( v.begin(), v.end() );
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a )
+{
+    return std::basic_string<CharT, Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+#endif // nssv_CPP11_OR_GREATER
+
+template< class CharT, class Traits, class Allocator >
+basic_string_view<CharT, Traits>
+to_string_view( std::basic_string<CharT, Traits, Allocator> const & s )
+{
+    return basic_string_view<CharT, Traits>( s.data(), s.size() );
+}
+
+}} // namespace nonstd::sv_lite
+
+#endif // nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+//
+// make types and algorithms available in namespace nonstd:
+//
+
+namespace nonstd {
+
+using sv_lite::basic_string_view;
+using sv_lite::string_view;
+using sv_lite::wstring_view;
+
+#if nssv_HAVE_WCHAR16_T
+using sv_lite::u16string_view;
+#endif
+#if nssv_HAVE_WCHAR32_T
+using sv_lite::u32string_view;
+#endif
+
+// literal "sv"
+
+using sv_lite::operator==;
+using sv_lite::operator!=;
+using sv_lite::operator<;
+using sv_lite::operator<=;
+using sv_lite::operator>;
+using sv_lite::operator>=;
+
+#if ! nssv_CONFIG_NO_STREAM_INSERTION
+using sv_lite::operator<<;
+#endif
+
+#if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+using sv_lite::to_string;
+using sv_lite::to_string_view;
+#endif
+
+} // namespace nonstd
+
+// 24.4.5 Hash support (C++11):
+
+// Note: The hash value of a string view object is equal to the hash value of
+// the corresponding string object.
+
+#if nssv_HAVE_STD_HASH
+
+#include <functional>
+
+namespace std {
+
+template<>
+struct hash< nonstd::string_view >
+{
+public:
+    std::size_t operator()( nonstd::string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::string>()( std::string( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::wstring_view >
+{
+public:
+    std::size_t operator()( nonstd::wstring_view v ) const nssv_noexcept
+    {
+        return std::hash<std::wstring>()( std::wstring( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::u16string_view >
+{
+public:
+    std::size_t operator()( nonstd::u16string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::u16string>()( std::u16string( v.data(), v.size() ) );
+    }
+};
+
+template<>
+struct hash< nonstd::u32string_view >
+{
+public:
+    std::size_t operator()( nonstd::u32string_view v ) const nssv_noexcept
+    {
+        return std::hash<std::u32string>()( std::u32string( v.data(), v.size() ) );
+    }
+};
+
+} // namespace std
+
+#endif // nssv_HAVE_STD_HASH
+
+nssv_RESTORE_WARNINGS()
+
+#endif // nssv_HAVE_STD_STRING_VIEW
+#endif // NONSTD_SV_LITE_H_INCLUDED

--- a/test/utils/impl/variant.hpp
+++ b/test/utils/impl/variant.hpp
@@ -1,0 +1,2743 @@
+// Copyright 2016-2018 by Martin Moene
+//
+// https://github.com/martinmoene/variant-lite
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#ifndef NONSTD_VARIANT_LITE_HPP
+#define NONSTD_VARIANT_LITE_HPP
+
+#define variant_lite_MAJOR  2
+#define variant_lite_MINOR  0
+#define variant_lite_PATCH  0
+
+#define variant_lite_VERSION  variant_STRINGIFY(variant_lite_MAJOR) "." variant_STRINGIFY(variant_lite_MINOR) "." variant_STRINGIFY(variant_lite_PATCH)
+
+#define variant_STRINGIFY(  x )  variant_STRINGIFY_( x )
+#define variant_STRINGIFY_( x )  #x
+
+// variant-lite configuration:
+
+#define variant_VARIANT_DEFAULT  0
+#define variant_VARIANT_NONSTD   1
+#define variant_VARIANT_STD      2
+
+// tweak header support:
+
+#ifdef __has_include
+# if __has_include(<nonstd/variant.tweak.hpp>)
+#  include <nonstd/variant.tweak.hpp>
+# endif
+#define variant_HAVE_TWEAK_HEADER  1
+#else
+#define variant_HAVE_TWEAK_HEADER  0
+//# pragma message("variant.hpp: Note: Tweak header not supported.")
+#endif
+
+// variant selection and configuration:
+
+#ifndef  variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO
+# define variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO  0
+#endif
+
+#ifndef  variant_CONFIG_OMIT_VARIANT_ALTERNATIVE_T_MACRO
+# define variant_CONFIG_OMIT_VARIANT_ALTERNATIVE_T_MACRO  0
+#endif
+
+// Control presence of exception handling (try and auto discover):
+
+#ifndef variant_CONFIG_NO_EXCEPTIONS
+# if defined(_MSC_VER)
+#  include <cstddef>    // for _HAS_EXCEPTIONS
+# endif
+# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (_HAS_EXCEPTIONS)
+#  define variant_CONFIG_NO_EXCEPTIONS  0
+# else
+#  define variant_CONFIG_NO_EXCEPTIONS  1
+# endif
+#endif
+
+// C++ language version detection (C++23 is speculative):
+// Note: VC14.0/1900 (VS2015) lacks too much from C++14.
+
+#ifndef   variant_CPLUSPLUS
+# if defined(_MSVC_LANG ) && !defined(__clang__)
+#  define variant_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define variant_CPLUSPLUS  __cplusplus
+# endif
+#endif
+
+#define variant_CPP98_OR_GREATER  ( variant_CPLUSPLUS >= 199711L )
+#define variant_CPP11_OR_GREATER  ( variant_CPLUSPLUS >= 201103L )
+#define variant_CPP11_OR_GREATER_ ( variant_CPLUSPLUS >= 201103L )
+#define variant_CPP14_OR_GREATER  ( variant_CPLUSPLUS >= 201402L )
+#define variant_CPP17_OR_GREATER  ( variant_CPLUSPLUS >= 201703L )
+#define variant_CPP20_OR_GREATER  ( variant_CPLUSPLUS >= 202002L )
+#define variant_CPP23_OR_GREATER  ( variant_CPLUSPLUS >= 202300L )
+
+// Use C++17 std::variant if available and requested:
+
+#if variant_CPP17_OR_GREATER && defined(__has_include )
+# if __has_include( <variant> )
+#  define variant_HAVE_STD_VARIANT  1
+# else
+#  define variant_HAVE_STD_VARIANT  0
+# endif
+#else
+# define  variant_HAVE_STD_VARIANT  0
+#endif
+
+#if !defined( variant_CONFIG_SELECT_VARIANT )
+# define variant_CONFIG_SELECT_VARIANT  ( variant_HAVE_STD_VARIANT ? variant_VARIANT_STD : variant_VARIANT_NONSTD )
+#endif
+
+#define  variant_USES_STD_VARIANT  ( (variant_CONFIG_SELECT_VARIANT == variant_VARIANT_STD) || ((variant_CONFIG_SELECT_VARIANT == variant_VARIANT_DEFAULT) && variant_HAVE_STD_VARIANT) )
+
+//
+// in_place: code duplicated in any-lite, expected-lite, optional-lite, value-ptr-lite, variant-lite:
+//
+
+#ifndef nonstd_lite_HAVE_IN_PLACE_TYPES
+#define nonstd_lite_HAVE_IN_PLACE_TYPES  1
+
+// C++17 std::in_place in <utility>:
+
+#if variant_CPP17_OR_GREATER
+
+#include <utility>
+
+namespace nonstd {
+
+using std::in_place;
+using std::in_place_type;
+using std::in_place_index;
+using std::in_place_t;
+using std::in_place_type_t;
+using std::in_place_index_t;
+
+#define nonstd_lite_in_place_t(      T)  std::in_place_t
+#define nonstd_lite_in_place_type_t( T)  std::in_place_type_t<T>
+#define nonstd_lite_in_place_index_t(K)  std::in_place_index_t<K>
+
+#define nonstd_lite_in_place(      T)    std::in_place_t{}
+#define nonstd_lite_in_place_type( T)    std::in_place_type_t<T>{}
+#define nonstd_lite_in_place_index(K)    std::in_place_index_t<K>{}
+
+} // namespace nonstd
+
+#else // variant_CPP17_OR_GREATER
+
+#include <cstddef>
+
+namespace nonstd {
+namespace detail {
+
+template< class T >
+struct in_place_type_tag {};
+
+template< std::size_t K >
+struct in_place_index_tag {};
+
+} // namespace detail
+
+struct in_place_t {};
+
+template< class T >
+inline in_place_t in_place( detail::in_place_type_tag<T> = detail::in_place_type_tag<T>() )
+{
+    return in_place_t();
+}
+
+template< std::size_t K >
+inline in_place_t in_place( detail::in_place_index_tag<K> = detail::in_place_index_tag<K>() )
+{
+    return in_place_t();
+}
+
+template< class T >
+inline in_place_t in_place_type( detail::in_place_type_tag<T> = detail::in_place_type_tag<T>() )
+{
+    return in_place_t();
+}
+
+template< std::size_t K >
+inline in_place_t in_place_index( detail::in_place_index_tag<K> = detail::in_place_index_tag<K>() )
+{
+    return in_place_t();
+}
+
+// mimic templated typedef:
+
+#define nonstd_lite_in_place_t(      T)  nonstd::in_place_t(&)( nonstd::detail::in_place_type_tag<T>  )
+#define nonstd_lite_in_place_type_t( T)  nonstd::in_place_t(&)( nonstd::detail::in_place_type_tag<T>  )
+#define nonstd_lite_in_place_index_t(K)  nonstd::in_place_t(&)( nonstd::detail::in_place_index_tag<K> )
+
+#define nonstd_lite_in_place(      T)    nonstd::in_place_type<T>
+#define nonstd_lite_in_place_type( T)    nonstd::in_place_type<T>
+#define nonstd_lite_in_place_index(K)    nonstd::in_place_index<K>
+
+} // namespace nonstd
+
+#endif // variant_CPP17_OR_GREATER
+#endif // nonstd_lite_HAVE_IN_PLACE_TYPES
+
+// in_place_index-like disambiguation tag identical for all C++ versions:
+
+namespace nonstd {
+namespace variants {
+namespace detail {
+
+template< std::size_t K >
+struct index_tag_t {};
+
+template< std::size_t K >
+inline void index_tag ( index_tag_t<K> = index_tag_t<K>() ) { }
+
+#define variant_index_tag_t(K)  void(&)( nonstd::variants::detail::index_tag_t<K> )
+#define variant_index_tag(K)    nonstd::variants::detail::index_tag<K>
+
+} // namespace detail
+} // namespace variants
+} // namespace nonstd
+
+//
+// Use C++17 std::variant:
+//
+
+#if variant_USES_STD_VARIANT
+
+#include <functional>   // std::hash<>
+#include <variant>
+
+#if ! variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO
+# define variant_size_V(T)  nonstd::variant_size<T>::value
+#endif
+
+#if ! variant_CONFIG_OMIT_VARIANT_ALTERNATIVE_T_MACRO
+# define variant_alternative_T(K,T)  typename nonstd::variant_alternative<K,T >::type
+#endif
+
+namespace nonstd {
+
+    using std::variant;
+    using std::monostate;
+    using std::bad_variant_access;
+    using std::variant_size;
+    using std::variant_size_v;
+    using std::variant_alternative;
+    using std::variant_alternative_t;
+    using std::hash;
+
+    using std::visit;
+    using std::holds_alternative;
+    using std::get;
+    using std::get_if;
+    using std::operator==;
+    using std::operator!=;
+    using std::operator<;
+    using std::operator<=;
+    using std::operator>;
+    using std::operator>=;
+    using std::swap;
+
+    constexpr auto variant_npos = std::variant_npos;
+}
+
+#else // variant_USES_STD_VARIANT
+
+#include <cstddef>
+#include <limits>
+#include <new>
+#include <utility>
+
+#if variant_CONFIG_NO_EXCEPTIONS
+# include <cassert>
+#else
+# include <stdexcept>
+#endif
+
+// variant-lite type and visitor argument count configuration (script/generate_header.py):
+
+#define variant_CONFIG_MAX_TYPE_COUNT  16
+#define variant_CONFIG_MAX_VISITOR_ARG_COUNT  5
+
+// variant-lite alignment configuration:
+
+#ifndef  variant_CONFIG_MAX_ALIGN_HACK
+# define variant_CONFIG_MAX_ALIGN_HACK  0
+#endif
+
+#ifndef  variant_CONFIG_ALIGN_AS
+// no default, used in #if defined()
+#endif
+
+#ifndef  variant_CONFIG_ALIGN_AS_FALLBACK
+# define variant_CONFIG_ALIGN_AS_FALLBACK  double
+#endif
+
+// half-open range [lo..hi):
+#define variant_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+
+// Compiler versions:
+//
+// MSVC++  6.0  _MSC_VER == 1200  variant_COMPILER_MSVC_VERSION ==  60  (Visual Studio 6.0)
+// MSVC++  7.0  _MSC_VER == 1300  variant_COMPILER_MSVC_VERSION ==  70  (Visual Studio .NET 2002)
+// MSVC++  7.1  _MSC_VER == 1310  variant_COMPILER_MSVC_VERSION ==  71  (Visual Studio .NET 2003)
+// MSVC++  8.0  _MSC_VER == 1400  variant_COMPILER_MSVC_VERSION ==  80  (Visual Studio 2005)
+// MSVC++  9.0  _MSC_VER == 1500  variant_COMPILER_MSVC_VERSION ==  90  (Visual Studio 2008)
+// MSVC++ 10.0  _MSC_VER == 1600  variant_COMPILER_MSVC_VERSION == 100  (Visual Studio 2010)
+// MSVC++ 11.0  _MSC_VER == 1700  variant_COMPILER_MSVC_VERSION == 110  (Visual Studio 2012)
+// MSVC++ 12.0  _MSC_VER == 1800  variant_COMPILER_MSVC_VERSION == 120  (Visual Studio 2013)
+// MSVC++ 14.0  _MSC_VER == 1900  variant_COMPILER_MSVC_VERSION == 140  (Visual Studio 2015)
+// MSVC++ 14.1  _MSC_VER >= 1910  variant_COMPILER_MSVC_VERSION == 141  (Visual Studio 2017)
+// MSVC++ 14.2  _MSC_VER >= 1920  variant_COMPILER_MSVC_VERSION == 142  (Visual Studio 2019)
+
+#if defined(_MSC_VER ) && !defined(__clang__)
+# define variant_COMPILER_MSVC_VER      (_MSC_VER )
+# define variant_COMPILER_MSVC_VERSION  (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+#else
+# define variant_COMPILER_MSVC_VER      0
+# define variant_COMPILER_MSVC_VERSION  0
+#endif
+
+#define variant_COMPILER_VERSION( major, minor, patch )  ( 10 * ( 10 * (major) + (minor) ) + (patch) )
+
+#if defined(__clang__)
+# define variant_COMPILER_CLANG_VERSION  variant_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#else
+# define variant_COMPILER_CLANG_VERSION  0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define variant_COMPILER_GNUC_VERSION  variant_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#else
+# define variant_COMPILER_GNUC_VERSION  0
+#endif
+
+#if variant_BETWEEN( variant_COMPILER_MSVC_VER, 1300, 1900 )
+# pragma warning( push )
+# pragma warning( disable: 4345 )   // initialization behavior changed
+#endif
+
+// Presence of language and library features:
+
+#define variant_HAVE( feature )  ( variant_HAVE_##feature )
+
+#ifdef _HAS_CPP0X
+# define variant_HAS_CPP0X  _HAS_CPP0X
+#else
+# define variant_HAS_CPP0X  0
+#endif
+
+// Unless defined otherwise below, consider VC14 as C++11 for variant-lite:
+
+#if variant_COMPILER_MSVC_VER >= 1900
+# undef  variant_CPP11_OR_GREATER
+# define variant_CPP11_OR_GREATER  1
+#endif
+
+#define variant_CPP11_90   (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1500)
+#define variant_CPP11_100  (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1600)
+#define variant_CPP11_110  (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1700)
+#define variant_CPP11_120  (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1800)
+#define variant_CPP11_140  (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1900)
+#define variant_CPP11_141  (variant_CPP11_OR_GREATER_ || variant_COMPILER_MSVC_VER >= 1910)
+
+#define variant_CPP14_000  (variant_CPP14_OR_GREATER)
+#define variant_CPP17_000  (variant_CPP17_OR_GREATER)
+
+// Presence of C++11 language features:
+
+#define variant_HAVE_CONSTEXPR_11       variant_CPP11_140
+#define variant_HAVE_INITIALIZER_LIST   variant_CPP11_120
+#define variant_HAVE_NOEXCEPT           variant_CPP11_140
+#define variant_HAVE_NULLPTR            variant_CPP11_100
+#define variant_HAVE_OVERRIDE           variant_CPP11_140
+
+// Presence of C++14 language features:
+
+#define variant_HAVE_CONSTEXPR_14       variant_CPP14_000
+
+// Presence of C++17 language features:
+
+// no flag
+
+// Presence of C++ library features:
+
+#define variant_HAVE_CONDITIONAL        variant_CPP11_120
+#define variant_HAVE_REMOVE_CV          variant_CPP11_120
+#define variant_HAVE_STD_ADD_POINTER    variant_CPP11_100
+#define variant_HAVE_TYPE_TRAITS        variant_CPP11_90
+#define variant_HAVE_ENABLE_IF          variant_CPP11_100
+#define variant_HAVE_IS_SAME            variant_CPP11_100
+
+#define variant_HAVE_TR1_TYPE_TRAITS    (!! variant_COMPILER_GNUC_VERSION )
+#define variant_HAVE_TR1_ADD_POINTER    (!! variant_COMPILER_GNUC_VERSION || variant_CPP11_90)
+
+// C++ feature usage:
+
+#if variant_HAVE_CONSTEXPR_11
+# define variant_constexpr constexpr
+#else
+# define variant_constexpr /*constexpr*/
+#endif
+
+#if variant_HAVE_CONSTEXPR_14
+# define variant_constexpr14 constexpr
+#else
+# define variant_constexpr14 /*constexpr*/
+#endif
+
+#if variant_HAVE_NOEXCEPT
+# define variant_noexcept noexcept
+#else
+# define variant_noexcept /*noexcept*/
+#endif
+
+#if variant_HAVE_NULLPTR
+# define variant_nullptr nullptr
+#else
+# define variant_nullptr NULL
+#endif
+
+#if variant_HAVE_OVERRIDE
+# define variant_override override
+#else
+# define variant_override /*override*/
+#endif
+
+// additional includes:
+
+#if variant_CPP11_OR_GREATER
+# include <functional>      // std::hash
+#endif
+
+#if variant_HAVE_INITIALIZER_LIST
+# include <initializer_list>
+#endif
+
+#if variant_HAVE_TYPE_TRAITS
+# include <type_traits>
+#elif variant_HAVE_TR1_TYPE_TRAITS
+# include <tr1/type_traits>
+#endif
+
+//
+// variant:
+//
+
+namespace nonstd { namespace variants {
+
+// C++11 emulation:
+
+namespace std11 {
+
+#if variant_HAVE_STD_ADD_POINTER
+
+using std::add_pointer;
+
+#elif variant_HAVE_TR1_ADD_POINTER
+
+using std::tr1::add_pointer;
+
+#else
+
+template< class T > struct remove_reference     { typedef T type; };
+template< class T > struct remove_reference<T&> { typedef T type; };
+
+template< class T > struct add_pointer
+{
+    typedef typename remove_reference<T>::type * type;
+};
+
+#endif // variant_HAVE_STD_ADD_POINTER
+
+#if variant_HAVE_REMOVE_CV
+
+using std::remove_cv;
+
+#else
+
+template< class T > struct remove_const          { typedef T type; };
+template< class T > struct remove_const<const T> { typedef T type; };
+
+template< class T > struct remove_volatile             { typedef T type; };
+template< class T > struct remove_volatile<volatile T> { typedef T type; };
+
+template< class T >
+struct remove_cv
+{
+    typedef typename remove_volatile<typename remove_const<T>::type>::type type;
+};
+
+#endif // variant_HAVE_REMOVE_CV
+
+#if variant_HAVE_CONDITIONAL
+
+using std::conditional;
+
+#else
+
+template< bool Cond, class Then, class Else >
+struct conditional;
+
+template< class Then, class Else >
+struct conditional< true , Then, Else > { typedef Then type; };
+
+template< class Then, class Else >
+struct conditional< false, Then, Else > { typedef Else type; };
+
+#endif // variant_HAVE_CONDITIONAL
+
+#if variant_HAVE_ENABLE_IF
+
+using std::enable_if;
+
+#else
+
+template< bool B, class T = void >
+struct enable_if { };
+
+template< class T >
+struct enable_if< true, T > { typedef T type; };
+
+#endif // variant_HAVE_ENABLE_IF
+
+#if variant_HAVE_IS_SAME
+
+using std::is_same;
+
+#else
+
+template< class T, class U >
+struct is_same {
+    enum V { value = 0 } ;
+};
+
+template< class T >
+struct is_same< T, T > {
+    enum V { value = 1 } ;
+};
+
+#endif // variant_HAVE_IS_SAME
+
+} // namespace std11
+
+// Method enabling
+
+#if variant_CPP11_OR_GREATER
+
+#define variant_REQUIRES_T(...) \
+    , typename std::enable_if< (__VA_ARGS__), int >::type = 0
+
+#define variant_REQUIRES_R(R, ...) \
+    typename std::enable_if< (__VA_ARGS__), R>::type
+
+#define variant_REQUIRES_A(...) \
+    , typename std::enable_if< (__VA_ARGS__), void*>::type = nullptr
+
+#endif // variant_CPP11_OR_GREATER
+
+#define variant_REQUIRES_0(...) \
+    template< bool B = (__VA_ARGS__), typename std11::enable_if<B, int>::type = 0 >
+
+#define variant_REQUIRES_B(...) \
+    , bool B = (__VA_ARGS__), typename std11::enable_if<B, int>::type = 0
+
+/// type traits C++17:
+
+namespace std17 {
+
+#if variant_CPP17_OR_GREATER
+
+using std::is_swappable;
+using std::is_nothrow_swappable;
+
+#elif variant_CPP11_OR_GREATER
+
+namespace detail {
+
+using std::swap;
+
+struct is_swappable
+{
+    template< typename T, typename = decltype( swap( std::declval<T&>(), std::declval<T&>() ) ) >
+    static std::true_type test( int );
+
+    template< typename >
+    static std::false_type test(...);
+};
+
+struct is_nothrow_swappable
+{
+    // wrap noexcept(epr) in separate function as work-around for VC140 (VS2015):
+
+    template< typename T >
+    static constexpr bool test()
+    {
+        return noexcept( swap( std::declval<T&>(), std::declval<T&>() ) );
+    }
+
+    template< typename T >
+    static auto test( int ) -> std::integral_constant<bool, test<T>()>{}
+
+    template< typename >
+    static std::false_type test(...);
+};
+
+} // namespace detail
+
+// is [nothow] swappable:
+
+template< typename T >
+struct is_swappable : decltype( detail::is_swappable::test<T>(0) ){};
+
+template< typename T >
+struct is_nothrow_swappable : decltype( detail::is_nothrow_swappable::test<T>(0) ){};
+
+#endif // variant_CPP17_OR_GREATER
+
+} // namespace std17
+
+// detail:
+
+namespace detail {
+
+// typelist:
+
+#define variant_TL1( T1 ) detail::typelist< T1, detail::nulltype >
+#define variant_TL2( T1, T2) detail::typelist< T1, variant_TL1( T2) >
+#define variant_TL3( T1, T2, T3) detail::typelist< T1, variant_TL2( T2, T3) >
+#define variant_TL4( T1, T2, T3, T4) detail::typelist< T1, variant_TL3( T2, T3, T4) >
+#define variant_TL5( T1, T2, T3, T4, T5) detail::typelist< T1, variant_TL4( T2, T3, T4, T5) >
+#define variant_TL6( T1, T2, T3, T4, T5, T6) detail::typelist< T1, variant_TL5( T2, T3, T4, T5, T6) >
+#define variant_TL7( T1, T2, T3, T4, T5, T6, T7) detail::typelist< T1, variant_TL6( T2, T3, T4, T5, T6, T7) >
+#define variant_TL8( T1, T2, T3, T4, T5, T6, T7, T8) detail::typelist< T1, variant_TL7( T2, T3, T4, T5, T6, T7, T8) >
+#define variant_TL9( T1, T2, T3, T4, T5, T6, T7, T8, T9) detail::typelist< T1, variant_TL8( T2, T3, T4, T5, T6, T7, T8, T9) >
+#define variant_TL10( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) detail::typelist< T1, variant_TL9( T2, T3, T4, T5, T6, T7, T8, T9, T10) >
+#define variant_TL11( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) detail::typelist< T1, variant_TL10( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) >
+#define variant_TL12( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) detail::typelist< T1, variant_TL11( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) >
+#define variant_TL13( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) detail::typelist< T1, variant_TL12( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) >
+#define variant_TL14( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) detail::typelist< T1, variant_TL13( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) >
+#define variant_TL15( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) detail::typelist< T1, variant_TL14( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) >
+#define variant_TL16( T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) detail::typelist< T1, variant_TL15( T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) >
+
+
+// variant parameter unused type tags:
+
+template< class T >
+struct TX : T
+{
+                        inline TX<T> operator+ (           ) const { return TX<T>();  }
+                        inline TX<T> operator- (           ) const { return TX<T>();  }
+
+                        inline TX<T> operator! (           ) const { return TX<T>();  }
+                        inline TX<T> operator~ (           ) const { return TX<T>();  }
+
+                        inline TX<T>*operator& (           ) const { return variant_nullptr; }
+
+    template< class U > inline TX<T> operator* ( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator/ ( U const & ) const { return TX<T>();  }
+
+    template< class U > inline TX<T> operator% ( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator+ ( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator- ( U const & ) const { return TX<T>();  }
+
+    template< class U > inline TX<T> operator<<( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator>>( U const & ) const { return TX<T>();  }
+
+                        inline bool  operator==( T const & ) const { return false; }
+                        inline bool  operator< ( T const & ) const { return false; }
+
+    template< class U > inline TX<T> operator& ( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator| ( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator^ ( U const & ) const { return TX<T>();  }
+
+    template< class U > inline TX<T> operator&&( U const & ) const { return TX<T>();  }
+    template< class U > inline TX<T> operator||( U const & ) const { return TX<T>();  }
+};
+
+struct S0{}; typedef TX<S0> T0;
+struct S1{}; typedef TX<S1> T1;
+struct S2{}; typedef TX<S2> T2;
+struct S3{}; typedef TX<S3> T3;
+struct S4{}; typedef TX<S4> T4;
+struct S5{}; typedef TX<S5> T5;
+struct S6{}; typedef TX<S6> T6;
+struct S7{}; typedef TX<S7> T7;
+struct S8{}; typedef TX<S8> T8;
+struct S9{}; typedef TX<S9> T9;
+struct S10{}; typedef TX<S10> T10;
+struct S11{}; typedef TX<S11> T11;
+struct S12{}; typedef TX<S12> T12;
+struct S13{}; typedef TX<S13> T13;
+struct S14{}; typedef TX<S14> T14;
+struct S15{}; typedef TX<S15> T15;
+
+
+struct nulltype{};
+
+template< class Head, class Tail >
+struct typelist
+{
+    typedef Head head;
+    typedef Tail tail;
+};
+
+// typelist max element size:
+
+template< class List >
+struct typelist_max;
+
+template<>
+struct typelist_max< nulltype >
+{
+    enum V { value = 0 } ;
+    typedef void type;
+};
+
+template< class Head, class Tail >
+struct typelist_max< typelist<Head, Tail> >
+{
+private:
+    enum TV { tail_value = size_t( typelist_max<Tail>::value ) };
+
+    typedef typename typelist_max<Tail>::type tail_type;
+
+public:
+    enum V { value = (sizeof( Head ) > tail_value) ? sizeof( Head ) : std::size_t( tail_value ) } ;
+
+    typedef typename std11::conditional< (sizeof( Head ) > tail_value), Head, tail_type>::type type;
+};
+
+#if variant_CPP11_OR_GREATER
+
+// typelist max alignof element type:
+
+template< class List >
+struct typelist_max_alignof;
+
+template<>
+struct typelist_max_alignof< nulltype >
+{
+    enum V { value = 0 } ;
+};
+
+template< class Head, class Tail >
+struct typelist_max_alignof< typelist<Head, Tail> >
+{
+private:
+    enum TV { tail_value = size_t( typelist_max_alignof<Tail>::value ) };
+
+public:
+    enum V { value = (alignof( Head ) > tail_value) ? alignof( Head ) : std::size_t( tail_value ) };
+};
+
+#endif
+
+// typelist size (length):
+
+template< class List >
+struct typelist_size
+{
+   enum V { value = 1 };
+};
+
+template<> struct typelist_size< T0 > { enum V { value = 0 }; };
+template<> struct typelist_size< T1 > { enum V { value = 0 }; };
+template<> struct typelist_size< T2 > { enum V { value = 0 }; };
+template<> struct typelist_size< T3 > { enum V { value = 0 }; };
+template<> struct typelist_size< T4 > { enum V { value = 0 }; };
+template<> struct typelist_size< T5 > { enum V { value = 0 }; };
+template<> struct typelist_size< T6 > { enum V { value = 0 }; };
+template<> struct typelist_size< T7 > { enum V { value = 0 }; };
+template<> struct typelist_size< T8 > { enum V { value = 0 }; };
+template<> struct typelist_size< T9 > { enum V { value = 0 }; };
+template<> struct typelist_size< T10 > { enum V { value = 0 }; };
+template<> struct typelist_size< T11 > { enum V { value = 0 }; };
+template<> struct typelist_size< T12 > { enum V { value = 0 }; };
+template<> struct typelist_size< T13 > { enum V { value = 0 }; };
+template<> struct typelist_size< T14 > { enum V { value = 0 }; };
+template<> struct typelist_size< T15 > { enum V { value = 0 }; };
+
+
+template<> struct typelist_size< nulltype > { enum V { value = 0 } ; };
+
+template< class Head, class Tail >
+struct typelist_size< typelist<Head, Tail> >
+{
+    enum V { value = size_t(typelist_size<Head>::value) + size_t(typelist_size<Tail>::value) };
+};
+
+// typelist index of type:
+
+template< class List, class T >
+struct typelist_index_of;
+
+template< class T >
+struct typelist_index_of< nulltype, T >
+{
+    enum V { value = -1 };
+};
+
+template< class Tail, class T >
+struct typelist_index_of< typelist<T, Tail>, T >
+{
+    enum V { value = 0 };
+};
+
+template< class Head, class Tail, class T >
+struct typelist_index_of< typelist<Head, Tail>, T >
+{
+private:
+    enum TV { nextVal = typelist_index_of<Tail, T>::value };
+
+public:
+    enum V { value = nextVal == -1 ? -1 : 1 + nextVal } ;
+};
+
+// typelist type at index:
+
+template< class List, std::size_t i>
+struct typelist_type_at;
+
+template< class Head, class Tail >
+struct typelist_type_at< typelist<Head, Tail>, 0 >
+{
+    typedef Head type;
+};
+
+template< class Head, class Tail, std::size_t i >
+struct typelist_type_at< typelist<Head, Tail>, i >
+{
+    typedef typename typelist_type_at<Tail, i - 1>::type type;
+};
+
+// typelist type is unique:
+
+template< class List, std::size_t CmpIndex, std::size_t LastChecked = typelist_size<List>::value >
+struct typelist_type_is_unique
+{
+private:
+    typedef typename typelist_type_at<List, CmpIndex>::type cmp_type;
+    typedef typename typelist_type_at<List, LastChecked - 1>::type cur_type;
+
+public:
+    enum V { value = ((CmpIndex == (LastChecked - 1)) | !std11::is_same<cmp_type, cur_type>::value)
+        && typelist_type_is_unique<List, CmpIndex, LastChecked - 1>::value } ;
+};
+
+template< class List, std::size_t CmpIndex >
+struct typelist_type_is_unique< List, CmpIndex, 0 >
+{
+    enum V { value = 1 } ;
+};
+
+template< class List, class T >
+struct typelist_contains_unique_type : typelist_type_is_unique< List, typelist_index_of< List, T >::value >
+{
+};
+
+#if variant_CONFIG_MAX_ALIGN_HACK
+
+// Max align, use most restricted type for alignment:
+
+#define variant_UNIQUE(  name )       variant_UNIQUE2( name, __LINE__ )
+#define variant_UNIQUE2( name, line ) variant_UNIQUE3( name, line )
+#define variant_UNIQUE3( name, line ) name ## line
+
+#define variant_ALIGN_TYPE( type ) \
+    type variant_UNIQUE( _t ); struct_t< type > variant_UNIQUE( _st )
+
+template< class T >
+struct struct_t { T _; };
+
+union max_align_t
+{
+    variant_ALIGN_TYPE( char );
+    variant_ALIGN_TYPE( short int );
+    variant_ALIGN_TYPE( int );
+    variant_ALIGN_TYPE( long int  );
+    variant_ALIGN_TYPE( float  );
+    variant_ALIGN_TYPE( double );
+    variant_ALIGN_TYPE( long double );
+    variant_ALIGN_TYPE( char * );
+    variant_ALIGN_TYPE( short int * );
+    variant_ALIGN_TYPE( int *  );
+    variant_ALIGN_TYPE( long int * );
+    variant_ALIGN_TYPE( float * );
+    variant_ALIGN_TYPE( double * );
+    variant_ALIGN_TYPE( long double * );
+    variant_ALIGN_TYPE( void * );
+
+#ifdef HAVE_LONG_LONG
+    variant_ALIGN_TYPE( long long );
+#endif
+
+    struct Unknown;
+
+    Unknown ( * variant_UNIQUE(_) )( Unknown );
+    Unknown * Unknown::* variant_UNIQUE(_);
+    Unknown ( Unknown::* variant_UNIQUE(_) )( Unknown );
+
+    struct_t< Unknown ( * )( Unknown)         > variant_UNIQUE(_);
+    struct_t< Unknown * Unknown::*            > variant_UNIQUE(_);
+    struct_t< Unknown ( Unknown::* )(Unknown) > variant_UNIQUE(_);
+};
+
+#undef variant_UNIQUE
+#undef variant_UNIQUE2
+#undef variant_UNIQUE3
+
+#undef variant_ALIGN_TYPE
+
+#elif defined( variant_CONFIG_ALIGN_AS ) // variant_CONFIG_MAX_ALIGN_HACK
+
+// Use user-specified type for alignment:
+
+#define variant_ALIGN_AS( unused ) \
+    variant_CONFIG_ALIGN_AS
+
+#else // variant_CONFIG_MAX_ALIGN_HACK
+
+// Determine POD type to use for alignment:
+
+#define variant_ALIGN_AS( to_align ) \
+    typename detail::type_of_size< detail::alignment_types, detail::alignment_of< to_align >::value >::type
+
+template< typename T >
+struct alignment_of;
+
+template< typename T >
+struct alignment_of_hack
+{
+    char c;
+    T t;
+    alignment_of_hack();
+};
+
+template< size_t A, size_t S >
+struct alignment_logic
+{
+    enum V { value = A < S ? A : S };
+};
+
+template< typename T >
+struct alignment_of
+{
+    enum V { value = alignment_logic<
+        sizeof( alignment_of_hack<T> ) - sizeof(T), sizeof(T) >::value };
+};
+
+template< typename List, size_t N >
+struct type_of_size
+{
+    typedef typename std11::conditional<
+        N == sizeof( typename List::head ),
+            typename List::head,
+            typename type_of_size<typename List::tail, N >::type >::type type;
+};
+
+template< size_t N >
+struct type_of_size< nulltype, N >
+{
+    typedef variant_CONFIG_ALIGN_AS_FALLBACK type;
+};
+
+template< typename T>
+struct struct_t { T _; };
+
+#define variant_ALIGN_TYPE( type ) \
+    typelist< type , typelist< struct_t< type >
+
+struct Unknown;
+
+typedef
+    variant_ALIGN_TYPE( char ),
+    variant_ALIGN_TYPE( short ),
+    variant_ALIGN_TYPE( int ),
+    variant_ALIGN_TYPE( long ),
+    variant_ALIGN_TYPE( float ),
+    variant_ALIGN_TYPE( double ),
+    variant_ALIGN_TYPE( long double ),
+
+    variant_ALIGN_TYPE( char *),
+    variant_ALIGN_TYPE( short * ),
+    variant_ALIGN_TYPE( int * ),
+    variant_ALIGN_TYPE( long * ),
+    variant_ALIGN_TYPE( float * ),
+    variant_ALIGN_TYPE( double * ),
+    variant_ALIGN_TYPE( long double * ),
+
+    variant_ALIGN_TYPE( Unknown ( * )( Unknown ) ),
+    variant_ALIGN_TYPE( Unknown * Unknown::*     ),
+    variant_ALIGN_TYPE( Unknown ( Unknown::* )( Unknown ) ),
+
+    nulltype
+    > > > > > > >    > > > > > > >
+    > > > > > > >    > > > > > > >
+    > > > > > >
+    alignment_types;
+
+#undef variant_ALIGN_TYPE
+
+#endif // variant_CONFIG_MAX_ALIGN_HACK
+
+#if variant_CPP11_OR_GREATER
+
+template< typename T>
+inline std::size_t hash( T const & v )
+{
+    return std::hash<T>()( v );
+}
+
+inline std::size_t hash( T0 const & ) { return 0; }
+inline std::size_t hash( T1 const & ) { return 0; }
+inline std::size_t hash( T2 const & ) { return 0; }
+inline std::size_t hash( T3 const & ) { return 0; }
+inline std::size_t hash( T4 const & ) { return 0; }
+inline std::size_t hash( T5 const & ) { return 0; }
+inline std::size_t hash( T6 const & ) { return 0; }
+inline std::size_t hash( T7 const & ) { return 0; }
+inline std::size_t hash( T8 const & ) { return 0; }
+inline std::size_t hash( T9 const & ) { return 0; }
+inline std::size_t hash( T10 const & ) { return 0; }
+inline std::size_t hash( T11 const & ) { return 0; }
+inline std::size_t hash( T12 const & ) { return 0; }
+inline std::size_t hash( T13 const & ) { return 0; }
+inline std::size_t hash( T14 const & ) { return 0; }
+inline std::size_t hash( T15 const & ) { return 0; }
+
+
+#endif // variant_CPP11_OR_GREATER
+
+
+
+
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+struct helper
+{
+    typedef signed char type_index_t;
+    typedef variant_TL16( T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 ) variant_types;
+
+    template< class U >
+    static U * as( void * data )
+    {
+        return reinterpret_cast<U*>( data );
+    }
+
+    template< class U >
+    static U const * as( void const * data )
+    {
+        return reinterpret_cast<const U*>( data );
+    }
+
+    static type_index_t to_index_t( std::size_t index )
+    {
+        return static_cast<type_index_t>( index );
+    }
+
+    static void destroy( type_index_t index, void * data )
+    {
+        switch ( index )
+        {
+        case 0: as<T0>( data )->~T0(); break;
+        case 1: as<T1>( data )->~T1(); break;
+        case 2: as<T2>( data )->~T2(); break;
+        case 3: as<T3>( data )->~T3(); break;
+        case 4: as<T4>( data )->~T4(); break;
+        case 5: as<T5>( data )->~T5(); break;
+        case 6: as<T6>( data )->~T6(); break;
+        case 7: as<T7>( data )->~T7(); break;
+        case 8: as<T8>( data )->~T8(); break;
+        case 9: as<T9>( data )->~T9(); break;
+        case 10: as<T10>( data )->~T10(); break;
+        case 11: as<T11>( data )->~T11(); break;
+        case 12: as<T12>( data )->~T12(); break;
+        case 13: as<T13>( data )->~T13(); break;
+        case 14: as<T14>( data )->~T14(); break;
+        case 15: as<T15>( data )->~T15(); break;
+        
+        }
+    }
+
+#if variant_CPP11_OR_GREATER
+    template< class T, class... Args >
+    static type_index_t construct_t( void * data, Args&&... args )
+    {
+        new( data ) T( std::forward<Args>(args)... );
+
+        return to_index_t( detail::typelist_index_of< variant_types, T>::value );
+    }
+
+    template< std::size_t K, class... Args >
+    static type_index_t construct_i( void * data, Args&&... args )
+    {
+        using type = typename detail::typelist_type_at< variant_types, K >::type;
+
+        construct_t< type >( data, std::forward<Args>(args)... );
+
+        return to_index_t( K );
+    }
+
+    static type_index_t move_construct( type_index_t const from_index, void * from_value, void * to_value )
+    {
+        switch ( from_index )
+        {
+        case 0: new( to_value ) T0( std::move( *as<T0>( from_value ) ) ); break;
+        case 1: new( to_value ) T1( std::move( *as<T1>( from_value ) ) ); break;
+        case 2: new( to_value ) T2( std::move( *as<T2>( from_value ) ) ); break;
+        case 3: new( to_value ) T3( std::move( *as<T3>( from_value ) ) ); break;
+        case 4: new( to_value ) T4( std::move( *as<T4>( from_value ) ) ); break;
+        case 5: new( to_value ) T5( std::move( *as<T5>( from_value ) ) ); break;
+        case 6: new( to_value ) T6( std::move( *as<T6>( from_value ) ) ); break;
+        case 7: new( to_value ) T7( std::move( *as<T7>( from_value ) ) ); break;
+        case 8: new( to_value ) T8( std::move( *as<T8>( from_value ) ) ); break;
+        case 9: new( to_value ) T9( std::move( *as<T9>( from_value ) ) ); break;
+        case 10: new( to_value ) T10( std::move( *as<T10>( from_value ) ) ); break;
+        case 11: new( to_value ) T11( std::move( *as<T11>( from_value ) ) ); break;
+        case 12: new( to_value ) T12( std::move( *as<T12>( from_value ) ) ); break;
+        case 13: new( to_value ) T13( std::move( *as<T13>( from_value ) ) ); break;
+        case 14: new( to_value ) T14( std::move( *as<T14>( from_value ) ) ); break;
+        case 15: new( to_value ) T15( std::move( *as<T15>( from_value ) ) ); break;
+        
+        }
+        return from_index;
+    }
+
+    static type_index_t move_assign( type_index_t const from_index, void * from_value, void * to_value )
+    {
+        switch ( from_index )
+        {
+        case 0: *as<T0>( to_value ) = std::move( *as<T0>( from_value ) ); break;
+        case 1: *as<T1>( to_value ) = std::move( *as<T1>( from_value ) ); break;
+        case 2: *as<T2>( to_value ) = std::move( *as<T2>( from_value ) ); break;
+        case 3: *as<T3>( to_value ) = std::move( *as<T3>( from_value ) ); break;
+        case 4: *as<T4>( to_value ) = std::move( *as<T4>( from_value ) ); break;
+        case 5: *as<T5>( to_value ) = std::move( *as<T5>( from_value ) ); break;
+        case 6: *as<T6>( to_value ) = std::move( *as<T6>( from_value ) ); break;
+        case 7: *as<T7>( to_value ) = std::move( *as<T7>( from_value ) ); break;
+        case 8: *as<T8>( to_value ) = std::move( *as<T8>( from_value ) ); break;
+        case 9: *as<T9>( to_value ) = std::move( *as<T9>( from_value ) ); break;
+        case 10: *as<T10>( to_value ) = std::move( *as<T10>( from_value ) ); break;
+        case 11: *as<T11>( to_value ) = std::move( *as<T11>( from_value ) ); break;
+        case 12: *as<T12>( to_value ) = std::move( *as<T12>( from_value ) ); break;
+        case 13: *as<T13>( to_value ) = std::move( *as<T13>( from_value ) ); break;
+        case 14: *as<T14>( to_value ) = std::move( *as<T14>( from_value ) ); break;
+        case 15: *as<T15>( to_value ) = std::move( *as<T15>( from_value ) ); break;
+        
+        }
+        return from_index;
+    }
+#endif
+
+    static type_index_t copy_construct( type_index_t const from_index, const void * from_value, void * to_value )
+    {
+        switch ( from_index )
+        {
+        case 0: new( to_value ) T0( *as<T0>( from_value ) ); break;
+        case 1: new( to_value ) T1( *as<T1>( from_value ) ); break;
+        case 2: new( to_value ) T2( *as<T2>( from_value ) ); break;
+        case 3: new( to_value ) T3( *as<T3>( from_value ) ); break;
+        case 4: new( to_value ) T4( *as<T4>( from_value ) ); break;
+        case 5: new( to_value ) T5( *as<T5>( from_value ) ); break;
+        case 6: new( to_value ) T6( *as<T6>( from_value ) ); break;
+        case 7: new( to_value ) T7( *as<T7>( from_value ) ); break;
+        case 8: new( to_value ) T8( *as<T8>( from_value ) ); break;
+        case 9: new( to_value ) T9( *as<T9>( from_value ) ); break;
+        case 10: new( to_value ) T10( *as<T10>( from_value ) ); break;
+        case 11: new( to_value ) T11( *as<T11>( from_value ) ); break;
+        case 12: new( to_value ) T12( *as<T12>( from_value ) ); break;
+        case 13: new( to_value ) T13( *as<T13>( from_value ) ); break;
+        case 14: new( to_value ) T14( *as<T14>( from_value ) ); break;
+        case 15: new( to_value ) T15( *as<T15>( from_value ) ); break;
+        
+        }
+        return from_index;
+    }
+
+    static type_index_t copy_assign( type_index_t const from_index, const void * from_value, void * to_value )
+    {
+        switch ( from_index )
+        {
+        case 0: *as<T0>( to_value ) = *as<T0>( from_value ); break;
+        case 1: *as<T1>( to_value ) = *as<T1>( from_value ); break;
+        case 2: *as<T2>( to_value ) = *as<T2>( from_value ); break;
+        case 3: *as<T3>( to_value ) = *as<T3>( from_value ); break;
+        case 4: *as<T4>( to_value ) = *as<T4>( from_value ); break;
+        case 5: *as<T5>( to_value ) = *as<T5>( from_value ); break;
+        case 6: *as<T6>( to_value ) = *as<T6>( from_value ); break;
+        case 7: *as<T7>( to_value ) = *as<T7>( from_value ); break;
+        case 8: *as<T8>( to_value ) = *as<T8>( from_value ); break;
+        case 9: *as<T9>( to_value ) = *as<T9>( from_value ); break;
+        case 10: *as<T10>( to_value ) = *as<T10>( from_value ); break;
+        case 11: *as<T11>( to_value ) = *as<T11>( from_value ); break;
+        case 12: *as<T12>( to_value ) = *as<T12>( from_value ); break;
+        case 13: *as<T13>( to_value ) = *as<T13>( from_value ); break;
+        case 14: *as<T14>( to_value ) = *as<T14>( from_value ); break;
+        case 15: *as<T15>( to_value ) = *as<T15>( from_value ); break;
+        
+        }
+        return from_index;
+    }
+};
+
+} // namespace detail
+
+//
+// Variant:
+//
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+class variant;
+
+// 19.7.8 Class monostate
+
+class monostate{};
+
+// 19.7.9 monostate relational operators
+
+inline variant_constexpr bool operator< ( monostate, monostate ) variant_noexcept { return false; }
+inline variant_constexpr bool operator> ( monostate, monostate ) variant_noexcept { return false; }
+inline variant_constexpr bool operator<=( monostate, monostate ) variant_noexcept { return true;  }
+inline variant_constexpr bool operator>=( monostate, monostate ) variant_noexcept { return true;  }
+inline variant_constexpr bool operator==( monostate, monostate ) variant_noexcept { return true;  }
+inline variant_constexpr bool operator!=( monostate, monostate ) variant_noexcept { return false; }
+
+// 19.7.4 variant helper classes
+
+// obtain the size of the variant's list of alternatives at compile time
+
+template< class T >
+struct variant_size; /* undefined */
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+struct variant_size< variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >
+{
+    enum _ { value = detail::typelist_size< variant_TL16(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) >::value };
+};
+
+#if variant_CPP14_OR_GREATER
+template< class T >
+constexpr std::size_t variant_size_v = variant_size<T>::value;
+#endif
+
+#if ! variant_CONFIG_OMIT_VARIANT_SIZE_V_MACRO
+# define variant_size_V(T)  nonstd::variant_size<T>::value
+#endif
+
+// obtain the type of the alternative specified by its index, at compile time:
+
+template< std::size_t K, class T >
+struct variant_alternative; /* undefined */
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+struct variant_alternative< K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >
+{
+    typedef typename detail::typelist_type_at<variant_TL16(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), K>::type type;
+};
+
+#if variant_CPP11_OR_GREATER
+template< std::size_t K, class T >
+using variant_alternative_t = typename variant_alternative<K, T>::type;
+#endif
+
+#if ! variant_CONFIG_OMIT_VARIANT_ALTERNATIVE_T_MACRO
+# define variant_alternative_T(K,T)  typename nonstd::variant_alternative<K,T >::type
+#endif
+
+// NTS:implement specializes the std::uses_allocator type trait
+// std::uses_allocator<nonstd::variant>
+
+// index of the variant in the invalid state (constant)
+
+#if variant_CPP11_OR_GREATER
+variant_constexpr std::size_t variant_npos = static_cast<std::size_t>( -1 );
+#else
+static const std::size_t variant_npos = static_cast<std::size_t>( -1 );
+#endif
+
+#if ! variant_CONFIG_NO_EXCEPTIONS
+
+// 19.7.11 Class bad_variant_access
+
+class bad_variant_access : public std::exception
+{
+public:
+#if variant_CPP11_OR_GREATER
+    virtual const char* what() const variant_noexcept variant_override
+#else
+    virtual const char* what() const throw()
+#endif
+    {
+        return "bad variant access";
+    }
+};
+
+#endif // variant_CONFIG_NO_EXCEPTIONS
+
+// 19.7.3 Class template variant
+
+template<
+    class T0,
+    class T1 = detail::T1,
+    class T2 = detail::T2,
+    class T3 = detail::T3,
+    class T4 = detail::T4,
+    class T5 = detail::T5,
+    class T6 = detail::T6,
+    class T7 = detail::T7,
+    class T8 = detail::T8,
+    class T9 = detail::T9,
+    class T10 = detail::T10,
+    class T11 = detail::T11,
+    class T12 = detail::T12,
+    class T13 = detail::T13,
+    class T14 = detail::T14,
+    class T15 = detail::T15
+    >
+class variant
+{
+    typedef detail::helper< T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 > helper_type;
+    typedef variant_TL16( T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15 ) variant_types;
+
+public:
+    // 19.7.3.1 Constructors
+
+    variant() : type_index( 0 ) { new( ptr() ) T0(); }
+
+#if variant_CPP11_OR_GREATER
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
+
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
+
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
+
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
+
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
+
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
+
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
+
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
+
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
+
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
+
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
+
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
+
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
+
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
+
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
+
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
+
+#else
+
+    variant( T0 const & t0 ) : type_index( 0 ) { new( ptr() ) T0( t0 ); }
+    variant( T1 const & t1 ) : type_index( 1 ) { new( ptr() ) T1( t1 ); }
+    variant( T2 const & t2 ) : type_index( 2 ) { new( ptr() ) T2( t2 ); }
+    variant( T3 const & t3 ) : type_index( 3 ) { new( ptr() ) T3( t3 ); }
+    variant( T4 const & t4 ) : type_index( 4 ) { new( ptr() ) T4( t4 ); }
+    variant( T5 const & t5 ) : type_index( 5 ) { new( ptr() ) T5( t5 ); }
+    variant( T6 const & t6 ) : type_index( 6 ) { new( ptr() ) T6( t6 ); }
+    variant( T7 const & t7 ) : type_index( 7 ) { new( ptr() ) T7( t7 ); }
+    variant( T8 const & t8 ) : type_index( 8 ) { new( ptr() ) T8( t8 ); }
+    variant( T9 const & t9 ) : type_index( 9 ) { new( ptr() ) T9( t9 ); }
+    variant( T10 const & t10 ) : type_index( 10 ) { new( ptr() ) T10( t10 ); }
+    variant( T11 const & t11 ) : type_index( 11 ) { new( ptr() ) T11( t11 ); }
+    variant( T12 const & t12 ) : type_index( 12 ) { new( ptr() ) T12( t12 ); }
+    variant( T13 const & t13 ) : type_index( 13 ) { new( ptr() ) T13( t13 ); }
+    variant( T14 const & t14 ) : type_index( 14 ) { new( ptr() ) T14( t14 ); }
+    variant( T15 const & t15 ) : type_index( 15 ) { new( ptr() ) T15( t15 ); }
+    
+#endif
+
+#if variant_CPP11_OR_GREATER
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant( T0 && t0 )
+        : type_index( 0 ) { new( ptr() ) T0( std::move(t0) ); }
+
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant( T1 && t1 )
+        : type_index( 1 ) { new( ptr() ) T1( std::move(t1) ); }
+
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant( T2 && t2 )
+        : type_index( 2 ) { new( ptr() ) T2( std::move(t2) ); }
+
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant( T3 && t3 )
+        : type_index( 3 ) { new( ptr() ) T3( std::move(t3) ); }
+
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant( T4 && t4 )
+        : type_index( 4 ) { new( ptr() ) T4( std::move(t4) ); }
+
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant( T5 && t5 )
+        : type_index( 5 ) { new( ptr() ) T5( std::move(t5) ); }
+
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant( T6 && t6 )
+        : type_index( 6 ) { new( ptr() ) T6( std::move(t6) ); }
+
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant( T7 && t7 )
+        : type_index( 7 ) { new( ptr() ) T7( std::move(t7) ); }
+
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant( T8 && t8 )
+        : type_index( 8 ) { new( ptr() ) T8( std::move(t8) ); }
+
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant( T9 && t9 )
+        : type_index( 9 ) { new( ptr() ) T9( std::move(t9) ); }
+
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant( T10 && t10 )
+        : type_index( 10 ) { new( ptr() ) T10( std::move(t10) ); }
+
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant( T11 && t11 )
+        : type_index( 11 ) { new( ptr() ) T11( std::move(t11) ); }
+
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant( T12 && t12 )
+        : type_index( 12 ) { new( ptr() ) T12( std::move(t12) ); }
+
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant( T13 && t13 )
+        : type_index( 13 ) { new( ptr() ) T13( std::move(t13) ); }
+
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant( T14 && t14 )
+        : type_index( 14 ) { new( ptr() ) T14( std::move(t14) ); }
+
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant( T15 && t15 )
+        : type_index( 15 ) { new( ptr() ) T15( std::move(t15) ); }
+#endif
+
+    variant(variant const & other)
+    : type_index( other.type_index )
+    {
+        (void) helper_type::copy_construct( other.type_index, other.ptr(), ptr() );
+    }
+
+#if variant_CPP11_OR_GREATER
+
+    variant( variant && other ) noexcept(
+        std::is_nothrow_move_constructible<T0>::value &&
+        std::is_nothrow_move_constructible<T1>::value &&
+        std::is_nothrow_move_constructible<T2>::value &&
+        std::is_nothrow_move_constructible<T3>::value &&
+        std::is_nothrow_move_constructible<T4>::value &&
+        std::is_nothrow_move_constructible<T5>::value &&
+        std::is_nothrow_move_constructible<T6>::value &&
+        std::is_nothrow_move_constructible<T7>::value &&
+        std::is_nothrow_move_constructible<T8>::value &&
+        std::is_nothrow_move_constructible<T9>::value &&
+        std::is_nothrow_move_constructible<T10>::value &&
+        std::is_nothrow_move_constructible<T11>::value &&
+        std::is_nothrow_move_constructible<T12>::value &&
+        std::is_nothrow_move_constructible<T13>::value &&
+        std::is_nothrow_move_constructible<T14>::value &&
+        std::is_nothrow_move_constructible<T15>::value)
+        : type_index( other.type_index )
+    {
+        (void) helper_type::move_construct( other.type_index, other.ptr(), ptr() );
+    }
+
+    template< std::size_t K >
+    using type_at_t = typename detail::typelist_type_at< variant_types, K >::type;
+
+    template< class T, class... Args
+        variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
+    >
+    explicit variant( nonstd_lite_in_place_type_t(T), Args&&... args)
+    {
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_t<T>( ptr(), std::forward<Args>(args)... );
+    }
+
+    template< class T, class U, class... Args
+        variant_REQUIRES_T( std::is_constructible< T, std::initializer_list<U>&, Args...>::value )
+    >
+    explicit variant( nonstd_lite_in_place_type_t(T), std::initializer_list<U> il, Args&&... args )
+    {
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_t<T>( ptr(), il, std::forward<Args>(args)... );
+    }
+
+    template< std::size_t K, class... Args
+        variant_REQUIRES_T( std::is_constructible< type_at_t<K>, Args...>::value )
+    >
+    explicit variant( nonstd_lite_in_place_index_t(K), Args&&... args )
+    {
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_i<K>( ptr(), std::forward<Args>(args)... );
+    }
+
+    template< size_t K, class U, class... Args
+        variant_REQUIRES_T( std::is_constructible< type_at_t<K>, std::initializer_list<U>&, Args...>::value )
+    >
+    explicit variant( nonstd_lite_in_place_index_t(K), std::initializer_list<U> il, Args&&... args )
+    {
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_i<K>( ptr(), il, std::forward<Args>(args)... );
+    }
+
+#endif // variant_CPP11_OR_GREATER
+
+    // 19.7.3.2 Destructor
+
+    ~variant()
+    {
+        if ( ! valueless_by_exception() )
+        {
+            helper_type::destroy( type_index, ptr() );
+        }
+    }
+
+    // 19.7.3.3 Assignment
+
+    variant & operator=( variant const & other )
+    {
+        return copy_assign( other );
+    }
+
+#if variant_CPP11_OR_GREATER
+
+    variant & operator=( variant && other ) noexcept(
+        std::is_nothrow_move_assignable<T0>::value &&
+        std::is_nothrow_move_assignable<T1>::value &&
+        std::is_nothrow_move_assignable<T2>::value &&
+        std::is_nothrow_move_assignable<T3>::value &&
+        std::is_nothrow_move_assignable<T4>::value &&
+        std::is_nothrow_move_assignable<T5>::value &&
+        std::is_nothrow_move_assignable<T6>::value &&
+        std::is_nothrow_move_assignable<T7>::value &&
+        std::is_nothrow_move_assignable<T8>::value &&
+        std::is_nothrow_move_assignable<T9>::value &&
+        std::is_nothrow_move_assignable<T10>::value &&
+        std::is_nothrow_move_assignable<T11>::value &&
+        std::is_nothrow_move_assignable<T12>::value &&
+        std::is_nothrow_move_assignable<T13>::value &&
+        std::is_nothrow_move_assignable<T14>::value &&
+        std::is_nothrow_move_assignable<T15>::value)
+        {
+        return move_assign( std::move( other ) );
+    }
+
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant & operator=( T0 &&      t0 ) { return assign_value<0>( std::move( t0 ) ); }
+
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant & operator=( T1 &&      t1 ) { return assign_value<1>( std::move( t1 ) ); }
+
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant & operator=( T2 &&      t2 ) { return assign_value<2>( std::move( t2 ) ); }
+
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant & operator=( T3 &&      t3 ) { return assign_value<3>( std::move( t3 ) ); }
+
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant & operator=( T4 &&      t4 ) { return assign_value<4>( std::move( t4 ) ); }
+
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant & operator=( T5 &&      t5 ) { return assign_value<5>( std::move( t5 ) ); }
+
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant & operator=( T6 &&      t6 ) { return assign_value<6>( std::move( t6 ) ); }
+
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant & operator=( T7 &&      t7 ) { return assign_value<7>( std::move( t7 ) ); }
+
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant & operator=( T8 &&      t8 ) { return assign_value<8>( std::move( t8 ) ); }
+
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant & operator=( T9 &&      t9 ) { return assign_value<9>( std::move( t9 ) ); }
+
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant & operator=( T10 &&      t10 ) { return assign_value<10>( std::move( t10 ) ); }
+
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant & operator=( T11 &&      t11 ) { return assign_value<11>( std::move( t11 ) ); }
+
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant & operator=( T12 &&      t12 ) { return assign_value<12>( std::move( t12 ) ); }
+
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant & operator=( T13 &&      t13 ) { return assign_value<13>( std::move( t13 ) ); }
+
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant & operator=( T14 &&      t14 ) { return assign_value<14>( std::move( t14 ) ); }
+
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant & operator=( T15 &&      t15 ) { return assign_value<15>( std::move( t15 ) ); }
+
+#endif
+
+#if variant_CPP11_OR_GREATER
+
+    template < variant_index_tag_t( 0 ) = variant_index_tag( 0 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 0 >::value) >
+    variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
+
+    template < variant_index_tag_t( 1 ) = variant_index_tag( 1 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 1 >::value) >
+    variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
+
+    template < variant_index_tag_t( 2 ) = variant_index_tag( 2 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 2 >::value) >
+    variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
+
+    template < variant_index_tag_t( 3 ) = variant_index_tag( 3 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 3 >::value) >
+    variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
+
+    template < variant_index_tag_t( 4 ) = variant_index_tag( 4 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 4 >::value) >
+    variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
+
+    template < variant_index_tag_t( 5 ) = variant_index_tag( 5 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 5 >::value) >
+    variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
+
+    template < variant_index_tag_t( 6 ) = variant_index_tag( 6 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 6 >::value) >
+    variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
+
+    template < variant_index_tag_t( 7 ) = variant_index_tag( 7 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 7 >::value) >
+    variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
+
+    template < variant_index_tag_t( 8 ) = variant_index_tag( 8 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 8 >::value) >
+    variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
+
+    template < variant_index_tag_t( 9 ) = variant_index_tag( 9 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 9 >::value) >
+    variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
+
+    template < variant_index_tag_t( 10 ) = variant_index_tag( 10 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 10 >::value) >
+    variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
+
+    template < variant_index_tag_t( 11 ) = variant_index_tag( 11 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 11 >::value) >
+    variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
+
+    template < variant_index_tag_t( 12 ) = variant_index_tag( 12 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 12 >::value) >
+    variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
+
+    template < variant_index_tag_t( 13 ) = variant_index_tag( 13 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 13 >::value) >
+    variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
+
+    template < variant_index_tag_t( 14 ) = variant_index_tag( 14 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 14 >::value) >
+    variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
+
+    template < variant_index_tag_t( 15 ) = variant_index_tag( 15 )
+        variant_REQUIRES_B(detail::typelist_type_is_unique< variant_types, 15 >::value) >
+    variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }
+
+#else
+
+    variant & operator=( T0 const & t0 ) { return assign_value<0>( t0 ); }
+    variant & operator=( T1 const & t1 ) { return assign_value<1>( t1 ); }
+    variant & operator=( T2 const & t2 ) { return assign_value<2>( t2 ); }
+    variant & operator=( T3 const & t3 ) { return assign_value<3>( t3 ); }
+    variant & operator=( T4 const & t4 ) { return assign_value<4>( t4 ); }
+    variant & operator=( T5 const & t5 ) { return assign_value<5>( t5 ); }
+    variant & operator=( T6 const & t6 ) { return assign_value<6>( t6 ); }
+    variant & operator=( T7 const & t7 ) { return assign_value<7>( t7 ); }
+    variant & operator=( T8 const & t8 ) { return assign_value<8>( t8 ); }
+    variant & operator=( T9 const & t9 ) { return assign_value<9>( t9 ); }
+    variant & operator=( T10 const & t10 ) { return assign_value<10>( t10 ); }
+    variant & operator=( T11 const & t11 ) { return assign_value<11>( t11 ); }
+    variant & operator=( T12 const & t12 ) { return assign_value<12>( t12 ); }
+    variant & operator=( T13 const & t13 ) { return assign_value<13>( t13 ); }
+    variant & operator=( T14 const & t14 ) { return assign_value<14>( t14 ); }
+    variant & operator=( T15 const & t15 ) { return assign_value<15>( t15 ); }
+    
+#endif
+
+    std::size_t index() const
+    {
+        return variant_npos_internal() == type_index ? variant_npos : static_cast<std::size_t>( type_index );
+    }
+
+    // 19.7.3.4 Modifiers
+
+#if variant_CPP11_OR_GREATER
+
+    template< class T, class... Args
+        variant_REQUIRES_T( std::is_constructible< T, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
+    >
+    T& emplace( Args&&... args )
+    {
+        helper_type::destroy( type_index, ptr() );
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_t<T>( ptr(), std::forward<Args>(args)... );
+
+        return *as<T>();
+    }
+
+    template< class T, class U, class... Args
+        variant_REQUIRES_T( std::is_constructible< T, std::initializer_list<U>&, Args...>::value )
+        variant_REQUIRES_T( detail::typelist_contains_unique_type< variant_types, T >::value )
+    >
+    T& emplace( std::initializer_list<U> il, Args&&... args )
+    {
+        helper_type::destroy( type_index, ptr() );
+        type_index = variant_npos_internal();
+        type_index = helper_type::template construct_t<T>( ptr(), il, std::forward<Args>(args)... );
+
+        return *as<T>();
+    }
+
+    template< size_t K, class... Args
+        variant_REQUIRES_T( std::is_constructible< type_at_t<K>, Args...>::value )
+    >
+    variant_alternative_t<K, variant> & emplace( Args&&... args )
+    {
+        return this->template emplace< type_at_t<K> >( std::forward<Args>(args)... );
+    }
+
+    template< size_t K, class U, class... Args
+        variant_REQUIRES_T( std::is_constructible< type_at_t<K>, std::initializer_list<U>&, Args...>::value )
+    >
+    variant_alternative_t<K, variant> & emplace( std::initializer_list<U> il, Args&&... args )
+    {
+        return this->template emplace< type_at_t<K> >( il, std::forward<Args>(args)... );
+    }
+
+#endif // variant_CPP11_OR_GREATER
+
+    // 19.7.3.5 Value status
+
+    bool valueless_by_exception() const
+    {
+        return type_index == variant_npos_internal();
+    }
+
+    // 19.7.3.6 Swap
+
+    void swap( variant & other )
+#if variant_CPP11_OR_GREATER
+        noexcept(
+            std::is_nothrow_move_constructible<T0>::value && std17::is_nothrow_swappable<T0>::value &&
+            std::is_nothrow_move_constructible<T1>::value && std17::is_nothrow_swappable<T1>::value &&
+            std::is_nothrow_move_constructible<T2>::value && std17::is_nothrow_swappable<T2>::value &&
+            std::is_nothrow_move_constructible<T3>::value && std17::is_nothrow_swappable<T3>::value &&
+            std::is_nothrow_move_constructible<T4>::value && std17::is_nothrow_swappable<T4>::value &&
+            std::is_nothrow_move_constructible<T5>::value && std17::is_nothrow_swappable<T5>::value &&
+            std::is_nothrow_move_constructible<T6>::value && std17::is_nothrow_swappable<T6>::value &&
+            std::is_nothrow_move_constructible<T7>::value && std17::is_nothrow_swappable<T7>::value &&
+            std::is_nothrow_move_constructible<T8>::value && std17::is_nothrow_swappable<T8>::value &&
+            std::is_nothrow_move_constructible<T9>::value && std17::is_nothrow_swappable<T9>::value &&
+            std::is_nothrow_move_constructible<T10>::value && std17::is_nothrow_swappable<T10>::value &&
+            std::is_nothrow_move_constructible<T11>::value && std17::is_nothrow_swappable<T11>::value &&
+            std::is_nothrow_move_constructible<T12>::value && std17::is_nothrow_swappable<T12>::value &&
+            std::is_nothrow_move_constructible<T13>::value && std17::is_nothrow_swappable<T13>::value &&
+            std::is_nothrow_move_constructible<T14>::value && std17::is_nothrow_swappable<T14>::value &&
+            std::is_nothrow_move_constructible<T15>::value && std17::is_nothrow_swappable<T15>::value 
+            
+        )
+#endif
+    {
+        if ( valueless_by_exception() && other.valueless_by_exception() )
+        {
+            // no effect
+        }
+        else if ( type_index == other.type_index )
+        {
+            this->swap_value( type_index, other );
+        }
+        else
+        {
+#if variant_CPP11_OR_GREATER
+            variant tmp( std::move( *this ) );
+            *this = std::move( other );
+            other = std::move( tmp );
+#else
+            variant tmp( *this );
+            *this = other;
+            other = tmp;
+#endif
+        }
+    }
+
+    //
+    // non-standard:
+    //
+
+    template< class T >
+    static variant_constexpr std::size_t index_of() variant_noexcept
+    {
+        return to_size_t( detail::typelist_index_of<variant_types, typename std11::remove_cv<T>::type >::value );
+    }
+
+    template< class T >
+    T & get()
+    {
+#if variant_CONFIG_NO_EXCEPTIONS
+        assert( index_of<T>() == index() );
+#else
+        if ( index_of<T>() != index() )
+        {
+            throw bad_variant_access();
+        }
+#endif
+        return *as<T>();
+    }
+
+    template< class T >
+    T const & get() const
+    {
+#if variant_CONFIG_NO_EXCEPTIONS
+        assert( index_of<T>() == index() );
+#else
+        if ( index_of<T>() != index() )
+        {
+            throw bad_variant_access();
+        }
+#endif
+        return *as<const T>();
+    }
+
+    template< std::size_t K >
+    typename variant_alternative< K, variant >::type &
+    get()
+    {
+        return this->template get< typename detail::typelist_type_at< variant_types, K >::type >();
+    }
+
+    template< std::size_t K >
+    typename variant_alternative< K, variant >::type const &
+    get() const
+    {
+        return this->template get< typename detail::typelist_type_at< variant_types, K >::type >();
+    }
+
+private:
+    typedef typename helper_type::type_index_t type_index_t;
+
+    void * ptr() variant_noexcept
+    {
+        return &data;
+    }
+
+    void const * ptr() const variant_noexcept
+    {
+        return &data;
+    }
+
+    template< class U >
+    U * as()
+    {
+        return reinterpret_cast<U*>( ptr() );
+    }
+
+    template< class U >
+    U const * as() const
+    {
+        return reinterpret_cast<U const *>( ptr() );
+    }
+
+    template< class U >
+    static variant_constexpr std::size_t to_size_t( U index )
+    {
+        return static_cast<std::size_t>( index );
+    }
+
+    variant_constexpr type_index_t variant_npos_internal() const variant_noexcept
+    {
+        return static_cast<type_index_t>( -1 );
+    }
+
+    variant & copy_assign( variant const & other )
+    {
+        if ( valueless_by_exception() && other.valueless_by_exception() )
+        {
+            // no effect
+        }
+        else if ( ! valueless_by_exception() && other.valueless_by_exception() )
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+        }
+        else if ( index() == other.index() )
+        {
+            type_index = helper_type::copy_assign( other.type_index, other.ptr(), ptr() );
+        }
+        else
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+            type_index = helper_type::copy_construct( other.type_index, other.ptr(), ptr() );
+        }
+        return *this;
+    }
+
+#if variant_CPP11_OR_GREATER
+
+    variant & move_assign( variant && other )
+    {
+        if ( valueless_by_exception() && other.valueless_by_exception() )
+        {
+            // no effect
+        }
+        else if ( ! valueless_by_exception() && other.valueless_by_exception() )
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+        }
+        else if ( index() == other.index() )
+        {
+            type_index = helper_type::move_assign( other.type_index, other.ptr(), ptr() );
+        }
+        else
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+            type_index = helper_type::move_construct( other.type_index, other.ptr(), ptr() );
+        }
+        return *this;
+    }
+
+    template< std::size_t K, class T >
+    variant & assign_value( T && value )
+    {
+        if( index() == K )
+        {
+            *as<T>() = std::forward<T>( value );
+        }
+        else
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+            new( ptr() ) T( std::forward<T>( value ) );
+            type_index = K;
+        }
+        return *this;
+    }
+
+#endif // variant_CPP11_OR_GREATER
+
+    template< std::size_t K, class T >
+    variant & assign_value( T const & value )
+    {
+        if( index() == K )
+        {
+            *as<T>() = value;
+        }
+        else
+        {
+            helper_type::destroy( type_index, ptr() );
+            type_index = variant_npos_internal();
+            new( ptr() ) T( value );
+            type_index = K;
+        }
+        return *this;
+    }
+
+    void swap_value( type_index_t index, variant & other )
+    {
+        using std::swap;
+        switch( index )
+        {
+            case 0: swap( this->get<0>(), other.get<0>() ); break;
+            case 1: swap( this->get<1>(), other.get<1>() ); break;
+            case 2: swap( this->get<2>(), other.get<2>() ); break;
+            case 3: swap( this->get<3>(), other.get<3>() ); break;
+            case 4: swap( this->get<4>(), other.get<4>() ); break;
+            case 5: swap( this->get<5>(), other.get<5>() ); break;
+            case 6: swap( this->get<6>(), other.get<6>() ); break;
+            case 7: swap( this->get<7>(), other.get<7>() ); break;
+            case 8: swap( this->get<8>(), other.get<8>() ); break;
+            case 9: swap( this->get<9>(), other.get<9>() ); break;
+            case 10: swap( this->get<10>(), other.get<10>() ); break;
+            case 11: swap( this->get<11>(), other.get<11>() ); break;
+            case 12: swap( this->get<12>(), other.get<12>() ); break;
+            case 13: swap( this->get<13>(), other.get<13>() ); break;
+            case 14: swap( this->get<14>(), other.get<14>() ); break;
+            case 15: swap( this->get<15>(), other.get<15>() ); break;
+            
+        }
+    }
+
+private:
+    enum { data_size  = detail::typelist_max< variant_types >::value };
+
+#if variant_CPP11_OR_GREATER
+
+    enum { data_align = detail::typelist_max_alignof< variant_types >::value };
+
+    using aligned_storage_t = typename std::aligned_storage< data_size, data_align >::type;
+    aligned_storage_t data;
+
+#elif variant_CONFIG_MAX_ALIGN_HACK
+
+    typedef union { unsigned char data[ data_size ]; } aligned_storage_t;
+
+    detail::max_align_t hack;
+    aligned_storage_t data;
+
+#else
+    typedef typename detail::typelist_max< variant_types >::type max_type;
+
+    typedef variant_ALIGN_AS( max_type ) align_as_type;
+
+    typedef union { align_as_type data[ 1 + ( data_size - 1 ) / sizeof(align_as_type) ]; } aligned_storage_t;
+    aligned_storage_t data;
+
+// #   undef variant_ALIGN_AS
+
+#endif // variant_CONFIG_MAX_ALIGN_HACK
+
+    type_index_t type_index;
+};
+
+// 19.7.5 Value access
+
+template< class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool holds_alternative( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v ) variant_noexcept
+{
+    return v.index() == variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>::template index_of<T>();
+}
+
+template< class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline R & get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & v, nonstd_lite_in_place_type_t(R) = nonstd_lite_in_place_type(R) )
+{
+    return v.template get<R>();
+}
+
+template< class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline R const & get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v, nonstd_lite_in_place_type_t(R) = nonstd_lite_in_place_type(R) )
+{
+    return v.template get<R>();
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename variant_alternative< K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type &
+get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & v, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+#if variant_CONFIG_NO_EXCEPTIONS
+    assert( K == v.index() );
+#else
+    if ( K != v.index() )
+    {
+        throw bad_variant_access();
+    }
+#endif
+    return v.template get<K>();
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename variant_alternative< K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type const &
+get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+#if variant_CONFIG_NO_EXCEPTIONS
+    assert( K == v.index() );
+#else
+    if ( K != v.index() )
+    {
+        throw bad_variant_access();
+    }
+#endif
+    return v.template get<K>();
+}
+
+#if variant_CPP11_OR_GREATER
+
+template< class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline R && get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> && v, nonstd_lite_in_place_type_t(R) = nonstd_lite_in_place_type(R) )
+{
+    return std::move(v.template get<R>());
+}
+
+template< class R, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline R const && get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const && v, nonstd_lite_in_place_type_t(R) = nonstd_lite_in_place_type(R) )
+{
+    return std::move(v.template get<R>());
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename variant_alternative< K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type &&
+get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> && v, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+#if variant_CONFIG_NO_EXCEPTIONS
+    assert( K == v.index() );
+#else
+    if ( K != v.index() )
+    {
+        throw bad_variant_access();
+    }
+#endif
+    return std::move(v.template get<K>());
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename variant_alternative< K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type const &&
+get( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const && v, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+#if variant_CONFIG_NO_EXCEPTIONS
+    assert( K == v.index() );
+#else
+    if ( K != v.index() )
+    {
+        throw bad_variant_access();
+    }
+#endif
+    return std::move(v.template get<K>());
+}
+
+#endif // variant_CPP11_OR_GREATER
+
+template< class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename std11::add_pointer<T>::type
+get_if( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> * pv, nonstd_lite_in_place_type_t(T) = nonstd_lite_in_place_type(T) )
+{
+    return ( pv->index() == variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>::template index_of<T>() ) ? &get<T>( *pv ) : variant_nullptr;
+}
+
+template< class T, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename std11::add_pointer<const T>::type
+get_if( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const * pv, nonstd_lite_in_place_type_t(T) = nonstd_lite_in_place_type(T))
+{
+    return ( pv->index() == variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>::template index_of<T>() ) ? &get<T>( *pv ) : variant_nullptr;
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename std11::add_pointer< typename variant_alternative<K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type >::type
+get_if( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> * pv, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+    return ( pv->index() == K ) ? &get<K>( *pv ) : variant_nullptr;
+}
+
+template< std::size_t K, class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline typename std11::add_pointer< const typename variant_alternative<K, variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::type >::type
+get_if( variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const * pv, nonstd_lite_in_place_index_t(K) = nonstd_lite_in_place_index(K) )
+{
+    return ( pv->index() == K ) ? &get<K>( *pv )  : variant_nullptr;
+}
+
+// 19.7.10 Specialized algorithms
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15
+#if variant_CPP11_OR_GREATER
+    variant_REQUIRES_T(
+        std::is_move_constructible<T0>::value && std17::is_swappable<T0>::value &&
+        std::is_move_constructible<T1>::value && std17::is_swappable<T1>::value &&
+        std::is_move_constructible<T2>::value && std17::is_swappable<T2>::value &&
+        std::is_move_constructible<T3>::value && std17::is_swappable<T3>::value &&
+        std::is_move_constructible<T4>::value && std17::is_swappable<T4>::value &&
+        std::is_move_constructible<T5>::value && std17::is_swappable<T5>::value &&
+        std::is_move_constructible<T6>::value && std17::is_swappable<T6>::value &&
+        std::is_move_constructible<T7>::value && std17::is_swappable<T7>::value &&
+        std::is_move_constructible<T8>::value && std17::is_swappable<T8>::value &&
+        std::is_move_constructible<T9>::value && std17::is_swappable<T9>::value &&
+        std::is_move_constructible<T10>::value && std17::is_swappable<T10>::value &&
+        std::is_move_constructible<T11>::value && std17::is_swappable<T11>::value &&
+        std::is_move_constructible<T12>::value && std17::is_swappable<T12>::value &&
+        std::is_move_constructible<T13>::value && std17::is_swappable<T13>::value &&
+        std::is_move_constructible<T14>::value && std17::is_swappable<T14>::value &&
+        std::is_move_constructible<T15>::value && std17::is_swappable<T15>::value 
+         )
+#endif
+>
+inline void swap(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & a,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> & b )
+#if variant_CPP11_OR_GREATER
+    noexcept( noexcept( a.swap( b ) ) )
+#endif
+{
+    a.swap( b );
+}
+
+// 19.7.7 Visitation
+
+// Variant 'visitor' implementation
+
+namespace detail
+{
+
+template< typename R, typename VT >
+struct VisitorApplicatorImpl
+{
+    template< typename Visitor, typename T >
+    static R apply(Visitor const& v, T const& arg)
+    {
+        return v(arg);
+    }
+};
+
+template< typename R, typename VT >
+struct VisitorApplicatorImpl<R, TX<VT> >
+{
+    template< typename Visitor, typename T >
+    static R apply(Visitor const&, T)
+    {
+        // prevent default construction of a const reference, see issue #39:
+        std::terminate();
+    }
+};
+
+template<typename R>
+struct VisitorApplicator;
+
+template< typename R, typename Visitor, typename V1 >
+struct VisitorUnwrapper;
+
+#if variant_CPP11_OR_GREATER
+template< size_t NumVars, typename R, typename Visitor, typename ... T >
+#else
+template< size_t NumVars, typename R, typename Visitor, typename T1, typename T2 = S0, typename T3 = S0, typename T4 = S0, typename T5 = S0 >
+#endif
+struct TypedVisitorUnwrapper;
+
+template< typename R, typename Visitor, typename T2 >
+struct TypedVisitorUnwrapper<2, R, Visitor, T2>
+{
+    const Visitor& visitor;
+    T2 const& val2;
+    
+    TypedVisitorUnwrapper(const Visitor& visitor_, T2 const& val2_)
+        : visitor(visitor_)
+        , val2(val2_)
+        
+    {
+    }
+
+    template<typename T>
+    R operator()(const T& val1) const
+    {
+        return visitor(val1, val2);
+    }
+};
+
+template< typename R, typename Visitor, typename T2, typename T3 >
+struct TypedVisitorUnwrapper<3, R, Visitor, T2, T3>
+{
+    const Visitor& visitor;
+    T2 const& val2;
+    T3 const& val3;
+    
+    TypedVisitorUnwrapper(const Visitor& visitor_, T2 const& val2_, T3 const& val3_)
+        : visitor(visitor_)
+        , val2(val2_)
+        , val3(val3_)
+        
+    {
+    }
+
+    template<typename T>
+    R operator()(const T& val1) const
+    {
+        return visitor(val1, val2, val3);
+    }
+};
+
+template< typename R, typename Visitor, typename T2, typename T3, typename T4 >
+struct TypedVisitorUnwrapper<4, R, Visitor, T2, T3, T4>
+{
+    const Visitor& visitor;
+    T2 const& val2;
+    T3 const& val3;
+    T4 const& val4;
+    
+    TypedVisitorUnwrapper(const Visitor& visitor_, T2 const& val2_, T3 const& val3_, T4 const& val4_)
+        : visitor(visitor_)
+        , val2(val2_)
+        , val3(val3_)
+        , val4(val4_)
+        
+    {
+    }
+
+    template<typename T>
+    R operator()(const T& val1) const
+    {
+        return visitor(val1, val2, val3, val4);
+    }
+};
+
+template< typename R, typename Visitor, typename T2, typename T3, typename T4, typename T5 >
+struct TypedVisitorUnwrapper<5, R, Visitor, T2, T3, T4, T5>
+{
+    const Visitor& visitor;
+    T2 const& val2;
+    T3 const& val3;
+    T4 const& val4;
+    T5 const& val5;
+    
+    TypedVisitorUnwrapper(const Visitor& visitor_, T2 const& val2_, T3 const& val3_, T4 const& val4_, T5 const& val5_)
+        : visitor(visitor_)
+        , val2(val2_)
+        , val3(val3_)
+        , val4(val4_)
+        , val5(val5_)
+        
+    {
+    }
+
+    template<typename T>
+    R operator()(const T& val1) const
+    {
+        return visitor(val1, val2, val3, val4, val5);
+    }
+};
+
+
+
+template<typename R, typename Visitor, typename V2>
+struct VisitorUnwrapper
+{
+    const Visitor& visitor;
+    const V2& r;
+
+    VisitorUnwrapper(const Visitor& visitor_, const V2& r_)
+        : visitor(visitor_)
+        , r(r_)
+    {
+    }
+
+    
+    template< typename T1 >
+    R operator()(T1 const& val1) const
+    {
+        typedef TypedVisitorUnwrapper<2, R, Visitor, T1> visitor_type;
+        return VisitorApplicator<R>::apply(visitor_type(visitor, val1), r);
+    }
+    
+    template< typename T1, typename T2 >
+    R operator()(T1 const& val1, T2 const& val2) const
+    {
+        typedef TypedVisitorUnwrapper<3, R, Visitor, T1, T2> visitor_type;
+        return VisitorApplicator<R>::apply(visitor_type(visitor, val1, val2), r);
+    }
+    
+    template< typename T1, typename T2, typename T3 >
+    R operator()(T1 const& val1, T2 const& val2, T3 const& val3) const
+    {
+        typedef TypedVisitorUnwrapper<4, R, Visitor, T1, T2, T3> visitor_type;
+        return VisitorApplicator<R>::apply(visitor_type(visitor, val1, val2, val3), r);
+    }
+    
+    template< typename T1, typename T2, typename T3, typename T4 >
+    R operator()(T1 const& val1, T2 const& val2, T3 const& val3, T4 const& val4) const
+    {
+        typedef TypedVisitorUnwrapper<5, R, Visitor, T1, T2, T3, T4> visitor_type;
+        return VisitorApplicator<R>::apply(visitor_type(visitor, val1, val2, val3, val4), r);
+    }
+    
+    template< typename T1, typename T2, typename T3, typename T4, typename T5 >
+    R operator()(T1 const& val1, T2 const& val2, T3 const& val3, T4 const& val4, T5 const& val5) const
+    {
+        typedef TypedVisitorUnwrapper<6, R, Visitor, T1, T2, T3, T4, T5> visitor_type;
+        return VisitorApplicator<R>::apply(visitor_type(visitor, val1, val2, val3, val4, val5), r);
+    }
+    
+};
+
+
+template<typename R>
+struct VisitorApplicator
+{
+    template<typename Visitor, typename V1>
+    static R apply(const Visitor& v, const V1& arg)
+    {
+        switch( arg.index() )
+        {
+            case 0: return apply_visitor<0>(v, arg);
+            case 1: return apply_visitor<1>(v, arg);
+            case 2: return apply_visitor<2>(v, arg);
+            case 3: return apply_visitor<3>(v, arg);
+            case 4: return apply_visitor<4>(v, arg);
+            case 5: return apply_visitor<5>(v, arg);
+            case 6: return apply_visitor<6>(v, arg);
+            case 7: return apply_visitor<7>(v, arg);
+            case 8: return apply_visitor<8>(v, arg);
+            case 9: return apply_visitor<9>(v, arg);
+            case 10: return apply_visitor<10>(v, arg);
+            case 11: return apply_visitor<11>(v, arg);
+            case 12: return apply_visitor<12>(v, arg);
+            case 13: return apply_visitor<13>(v, arg);
+            case 14: return apply_visitor<14>(v, arg);
+            case 15: return apply_visitor<15>(v, arg);
+            
+            // prevent default construction of a const reference, see issue #39:
+            default: std::terminate();
+        }
+    }
+
+    template<size_t Idx, typename Visitor, typename V1>
+    static R apply_visitor(const Visitor& v, const V1& arg)
+    {
+
+#if variant_CPP11_OR_GREATER
+        typedef typename variant_alternative<Idx, typename std::decay<V1>::type>::type value_type;
+#else
+        typedef typename variant_alternative<Idx, V1>::type value_type;
+#endif
+        return VisitorApplicatorImpl<R, value_type>::apply(v, get<Idx>(arg));
+    }
+
+#if variant_CPP11_OR_GREATER
+    template<typename Visitor, typename V1, typename V2, typename ... V>
+    static R apply(const Visitor& v, const V1& arg1, const V2& arg2, const V ... args)
+    {
+        typedef VisitorUnwrapper<R, Visitor, V1> Unwrapper;
+        Unwrapper unwrapper(v, arg1);
+        return apply(unwrapper, arg2, args ...);
+    }
+#else
+    
+    template< typename Visitor, typename V1, typename V2 >
+    static R apply(const Visitor& v, V1 const& arg1, V2 const& arg2)
+    {
+        typedef VisitorUnwrapper<R, Visitor, V1> Unwrapper;
+        Unwrapper unwrapper(v, arg1);
+        return apply(unwrapper, arg2);
+    }
+    
+    template< typename Visitor, typename V1, typename V2, typename V3 >
+    static R apply(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3)
+    {
+        typedef VisitorUnwrapper<R, Visitor, V1> Unwrapper;
+        Unwrapper unwrapper(v, arg1);
+        return apply(unwrapper, arg2, arg3);
+    }
+    
+    template< typename Visitor, typename V1, typename V2, typename V3, typename V4 >
+    static R apply(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3, V4 const& arg4)
+    {
+        typedef VisitorUnwrapper<R, Visitor, V1> Unwrapper;
+        Unwrapper unwrapper(v, arg1);
+        return apply(unwrapper, arg2, arg3, arg4);
+    }
+    
+    template< typename Visitor, typename V1, typename V2, typename V3, typename V4, typename V5 >
+    static R apply(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3, V4 const& arg4, V5 const& arg5)
+    {
+        typedef VisitorUnwrapper<R, Visitor, V1> Unwrapper;
+        Unwrapper unwrapper(v, arg1);
+        return apply(unwrapper, arg2, arg3, arg4, arg5);
+    }
+    
+#endif
+};
+
+#if variant_CPP11_OR_GREATER
+template< size_t NumVars, typename Visitor, typename ... V >
+struct VisitorImpl
+{
+    typedef decltype(std::declval<Visitor>()(get<0>(static_cast<const V&>(std::declval<V>()))...)) result_type;
+    typedef VisitorApplicator<result_type> applicator_type;
+};
+#endif
+} // detail
+
+#if variant_CPP11_OR_GREATER
+// No perfect forwarding here in order to simplify code
+template< typename Visitor, typename ... V >
+inline auto visit(Visitor const& v, V const& ... vars) -> typename detail::VisitorImpl<sizeof ... (V), Visitor, V... > ::result_type
+{
+    typedef detail::VisitorImpl<sizeof ... (V), Visitor, V... > impl_type;
+    return impl_type::applicator_type::apply(v, vars...);
+}
+#else
+
+template< typename R, typename Visitor, typename V1 >
+inline R visit(const Visitor& v, V1 const& arg1)
+{
+    return detail::VisitorApplicator<R>::apply(v, arg1);
+}
+
+template< typename R, typename Visitor, typename V1, typename V2 >
+inline R visit(const Visitor& v, V1 const& arg1, V2 const& arg2)
+{
+    return detail::VisitorApplicator<R>::apply(v, arg1, arg2);
+}
+
+template< typename R, typename Visitor, typename V1, typename V2, typename V3 >
+inline R visit(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3)
+{
+    return detail::VisitorApplicator<R>::apply(v, arg1, arg2, arg3);
+}
+
+template< typename R, typename Visitor, typename V1, typename V2, typename V3, typename V4 >
+inline R visit(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3, V4 const& arg4)
+{
+    return detail::VisitorApplicator<R>::apply(v, arg1, arg2, arg3, arg4);
+}
+
+template< typename R, typename Visitor, typename V1, typename V2, typename V3, typename V4, typename V5 >
+inline R visit(const Visitor& v, V1 const& arg1, V2 const& arg2, V3 const& arg3, V4 const& arg4, V5 const& arg5)
+{
+    return detail::VisitorApplicator<R>::apply(v, arg1, arg2, arg3, arg4, arg5);
+}
+
+#endif
+
+// 19.7.6 Relational operators
+
+namespace detail {
+
+template< class Variant >
+struct Comparator
+{
+    static inline bool equal( Variant const & v, Variant const & w )
+    {
+        switch( v.index() )
+        {
+            case 0: return get<0>( v ) == get<0>( w );
+            case 1: return get<1>( v ) == get<1>( w );
+            case 2: return get<2>( v ) == get<2>( w );
+            case 3: return get<3>( v ) == get<3>( w );
+            case 4: return get<4>( v ) == get<4>( w );
+            case 5: return get<5>( v ) == get<5>( w );
+            case 6: return get<6>( v ) == get<6>( w );
+            case 7: return get<7>( v ) == get<7>( w );
+            case 8: return get<8>( v ) == get<8>( w );
+            case 9: return get<9>( v ) == get<9>( w );
+            case 10: return get<10>( v ) == get<10>( w );
+            case 11: return get<11>( v ) == get<11>( w );
+            case 12: return get<12>( v ) == get<12>( w );
+            case 13: return get<13>( v ) == get<13>( w );
+            case 14: return get<14>( v ) == get<14>( w );
+            case 15: return get<15>( v ) == get<15>( w );
+            
+            default: return false;
+        }
+    }
+
+    static inline bool less_than( Variant const & v, Variant const & w )
+    {
+        switch( v.index() )
+        {
+            case 0: return get<0>( v ) < get<0>( w );
+            case 1: return get<1>( v ) < get<1>( w );
+            case 2: return get<2>( v ) < get<2>( w );
+            case 3: return get<3>( v ) < get<3>( w );
+            case 4: return get<4>( v ) < get<4>( w );
+            case 5: return get<5>( v ) < get<5>( w );
+            case 6: return get<6>( v ) < get<6>( w );
+            case 7: return get<7>( v ) < get<7>( w );
+            case 8: return get<8>( v ) < get<8>( w );
+            case 9: return get<9>( v ) < get<9>( w );
+            case 10: return get<10>( v ) < get<10>( w );
+            case 11: return get<11>( v ) < get<11>( w );
+            case 12: return get<12>( v ) < get<12>( w );
+            case 13: return get<13>( v ) < get<13>( w );
+            case 14: return get<14>( v ) < get<14>( w );
+            case 15: return get<15>( v ) < get<15>( w );
+            
+            default: return false;
+        }
+    }
+};
+
+} //namespace detail
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator==(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    if      ( v.index() != w.index()     ) return false;
+    else if ( v.valueless_by_exception() ) return true;
+    else                                   return detail::Comparator< variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::equal( v, w );
+}
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator!=(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    return ! ( v == w );
+}
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator<(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    if      ( w.valueless_by_exception() ) return false;
+    else if ( v.valueless_by_exception() ) return true;
+    else if ( v.index() < w.index()      ) return true;
+    else if ( v.index() > w.index()      ) return false;
+    else                                   return detail::Comparator< variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >::less_than( v, w );
+}
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator>(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    return w < v;
+}
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator<=(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    return ! ( v > w );
+}
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+inline bool operator>=(
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v,
+    variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & w )
+{
+    return ! ( v < w );
+}
+
+} // namespace variants
+
+using namespace variants;
+
+} // namespace nonstd
+
+#if variant_CPP11_OR_GREATER
+
+// 19.7.12 Hash support
+
+namespace std {
+
+template<>
+struct hash< nonstd::monostate >
+{
+    std::size_t operator()( nonstd::monostate ) const variant_noexcept
+    {
+        return 42;
+    }
+};
+
+template< class T0, class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15 >
+struct hash< nonstd::variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> >
+{
+    std::size_t operator()( nonstd::variant<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> const & v ) const variant_noexcept
+    {
+        namespace nvd = nonstd::variants::detail;
+
+        switch( v.index() )
+        {
+            case 0: return nvd::hash( 0 ) ^ nvd::hash( get<0>( v ) );
+            case 1: return nvd::hash( 1 ) ^ nvd::hash( get<1>( v ) );
+            case 2: return nvd::hash( 2 ) ^ nvd::hash( get<2>( v ) );
+            case 3: return nvd::hash( 3 ) ^ nvd::hash( get<3>( v ) );
+            case 4: return nvd::hash( 4 ) ^ nvd::hash( get<4>( v ) );
+            case 5: return nvd::hash( 5 ) ^ nvd::hash( get<5>( v ) );
+            case 6: return nvd::hash( 6 ) ^ nvd::hash( get<6>( v ) );
+            case 7: return nvd::hash( 7 ) ^ nvd::hash( get<7>( v ) );
+            case 8: return nvd::hash( 8 ) ^ nvd::hash( get<8>( v ) );
+            case 9: return nvd::hash( 9 ) ^ nvd::hash( get<9>( v ) );
+            case 10: return nvd::hash( 10 ) ^ nvd::hash( get<10>( v ) );
+            case 11: return nvd::hash( 11 ) ^ nvd::hash( get<11>( v ) );
+            case 12: return nvd::hash( 12 ) ^ nvd::hash( get<12>( v ) );
+            case 13: return nvd::hash( 13 ) ^ nvd::hash( get<13>( v ) );
+            case 14: return nvd::hash( 14 ) ^ nvd::hash( get<14>( v ) );
+            case 15: return nvd::hash( 15 ) ^ nvd::hash( get<15>( v ) );
+            
+            default: return 0;
+        }
+    }
+};
+
+} //namespace std
+
+#endif // variant_CPP11_OR_GREATER
+
+#if variant_BETWEEN( variant_COMPILER_MSVC_VER, 1300, 1900 )
+# pragma warning( pop )
+#endif
+
+#endif // variant_USES_STD_VARIANT
+
+#endif // NONSTD_VARIANT_LITE_HPP

--- a/test/utils/role.hpp
+++ b/test/utils/role.hpp
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_ROLE_HPP
+#define BOOST_BEAST_ROLE_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+
+namespace boost {
+namespace beast {
+
+/** The role of local or remote peer.
+
+    Whether the endpoint is a client or server affects the
+    behavior of teardown.
+    The teardown behavior also depends on the type of the stream
+    being torn down.
+    
+    The default implementation of teardown for regular
+    TCP/IP sockets is as follows:
+
+    @li In the client role, a TCP/IP shutdown is sent after
+    reading all remaining data on the connection.
+
+    @li In the server role, a TCP/IP shutdown is sent before
+    reading all remaining data on the connection.
+
+    When the next layer type is a `net::ssl::stream`,
+    the connection is closed by performing the SSL closing
+    handshake corresponding to the role type, client or server.
+*/
+enum class role_type
+{
+    /// The stream is operating as a client.
+    client,
+
+    /// The stream is operating as a server.
+    server
+};
+
+} // beast
+} // boost
+
+#endif

--- a/test/utils/role.hpp
+++ b/test/utils/role.hpp
@@ -10,10 +10,9 @@
 #ifndef BOOST_BEAST_ROLE_HPP
 #define BOOST_BEAST_ROLE_HPP
 
-#include <boost/beast/core/detail/config.hpp>
-
 namespace boost {
-namespace beast {
+namespace wintls {
+namespace test {
 
 /** The role of local or remote peer.
 
@@ -21,7 +20,7 @@ namespace beast {
     behavior of teardown.
     The teardown behavior also depends on the type of the stream
     being torn down.
-    
+
     The default implementation of teardown for regular
     TCP/IP sockets is as follows:
 
@@ -44,7 +43,8 @@ enum class role_type
     server
 };
 
-} // beast
+} // test
+} // wintls
 } // boost
 
 #endif

--- a/test/utils/service_base.hpp
+++ b/test/utils/service_base.hpp
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_SERVICE_BASE_HPP
+#define BOOST_BEAST_DETAIL_SERVICE_BASE_HPP
+
+#include <boost/asio/execution_context.hpp>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template<class T>
+struct service_base : net::execution_context::service
+{
+    static net::execution_context::id const id;
+
+    explicit
+    service_base(net::execution_context& ctx)
+        : net::execution_context::service(ctx)
+    {
+    }
+};
+
+template<class T>
+net::execution_context::id const service_base<T>::id;
+
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/test/utils/stream.hpp
+++ b/test/utils/stream.hpp
@@ -1,0 +1,629 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_STREAM_HPP
+#define BOOST_BEAST_TEST_STREAM_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/bind_handler.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
+#include <boost/beast/core/role.hpp>
+#include <boost/beast/core/string.hpp>
+#include <boost/beast/_experimental/test/fail_count.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/assert.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
+#include <boost/throw_exception.hpp>
+#include <condition_variable>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#if ! BOOST_BEAST_DOXYGEN
+namespace boost {
+namespace asio {
+namespace ssl {
+template<typename> class stream;
+} // ssl
+} // asio
+} // boost
+#endif
+
+namespace boost {
+namespace beast {
+namespace test {
+
+/** A two-way socket useful for unit testing
+
+    An instance of this class simulates a traditional socket,
+    while also providing features useful for unit testing.
+    Each endpoint maintains an independent buffer called
+    the input area. Writes from one endpoint append data
+    to the peer's pending input area. When an endpoint performs
+    a read and data is present in the input area, the data is
+    delivered to the blocking or asynchronous operation. Otherwise
+    the operation is blocked or deferred until data is made
+    available, or until the endpoints become disconnected.
+
+    These streams may be used anywhere an algorithm accepts a
+    reference to a synchronous or asynchronous read or write
+    stream. It is possible to use a test stream in a call to
+    `net::read_until`, or in a call to
+    @ref boost::beast::http::async_write for example.
+
+    As with Boost.Asio I/O objects, a @ref stream constructs
+    with a reference to the `net::io_context` to use for
+    handling asynchronous I/O. For asynchronous operations, the
+    stream follows the same rules as a traditional asio socket
+    with respect to how completion handlers for asynchronous
+    operations are performed.
+
+    To facilitate testing, these streams support some additional
+    features:
+
+    @li The input area, represented by a @ref beast::basic_flat_buffer,
+    may be directly accessed by the caller to inspect the contents
+    before or after the remote endpoint writes data. This allows
+    a unit test to verify that the received data matches.
+
+    @li Data may be manually appended to the input area. This data
+    will delivered in the next call to
+    @ref stream::read_some or @ref stream::async_read_some.
+    This allows predefined test vectors to be set up for testing
+    read algorithms.
+
+    @li The stream may be constructed with a fail count. The
+    stream will eventually fail with a predefined error after a
+    certain number of operations, where the number of operations
+    is controlled by the test. When a test loops over a range of
+    operation counts, it is possible to exercise every possible
+    point of failure in the algorithm being tested. When used
+    correctly the technique allows the tests to reach a high
+    percentage of code coverage.
+
+    @par Thread Safety
+        @e Distinct @e objects: Safe.@n
+        @e Shared @e objects: Unsafe.
+        The application must also ensure that all asynchronous
+        operations are performed within the same implicit or explicit strand.
+
+    @par Concepts
+        @li <em>SyncReadStream</em>
+        @li <em>SyncWriteStream</em>
+        @li <em>AsyncReadStream</em>
+        @li <em>AsyncWriteStream</em>
+*/
+class stream
+{
+    struct state;
+
+    boost::shared_ptr<state> in_;
+    boost::weak_ptr<state> out_;
+
+    enum class status
+    {
+        ok,
+        eof,
+    };
+
+    class service;
+    struct service_impl;
+
+    struct read_op_base
+    {
+        virtual ~read_op_base() = default;
+        virtual void operator()(error_code ec) = 0;
+    };
+
+    struct state
+    {
+        friend class stream;
+
+        net::io_context& ioc;
+        boost::weak_ptr<service_impl> wp;
+        std::mutex m;
+        flat_buffer b;
+        std::condition_variable cv;
+        std::unique_ptr<read_op_base> op;
+        status code = status::ok;
+        fail_count* fc = nullptr;
+        std::size_t nread = 0;
+        std::size_t nread_bytes = 0;
+        std::size_t nwrite = 0;
+        std::size_t nwrite_bytes = 0;
+        std::size_t read_max =
+            (std::numeric_limits<std::size_t>::max)();
+        std::size_t write_max =
+            (std::numeric_limits<std::size_t>::max)();
+
+        BOOST_BEAST_DECL
+        state(
+            net::io_context& ioc_,
+            boost::weak_ptr<service_impl> wp_,
+            fail_count* fc_);
+
+
+        BOOST_BEAST_DECL
+        ~state();
+
+        BOOST_BEAST_DECL
+        void
+        remove() noexcept;
+
+        BOOST_BEAST_DECL
+        void
+        notify_read();
+
+        BOOST_BEAST_DECL
+        void
+        cancel_read();
+    };
+
+    template<class Handler, class Buffers>
+    class read_op;
+
+    struct run_read_op;
+    struct run_write_op;
+
+    BOOST_BEAST_DECL
+    static
+    void
+    initiate_read(
+        boost::shared_ptr<state> const& in,
+        std::unique_ptr<read_op_base>&& op,
+        std::size_t buf_size);
+
+#if ! BOOST_BEAST_DOXYGEN
+    // boost::asio::ssl::stream needs these
+    // DEPRECATED
+    template<class>
+    friend class boost::asio::ssl::stream;
+    // DEPRECATED
+    using lowest_layer_type = stream;
+    // DEPRECATED
+    lowest_layer_type&
+    lowest_layer() noexcept
+    {
+        return *this;
+    }
+    // DEPRECATED
+    lowest_layer_type const&
+    lowest_layer() const noexcept
+    {
+        return *this;
+    }
+#endif
+
+public:
+    using buffer_type = flat_buffer;
+
+    /** Destructor
+
+        If an asynchronous read operation is pending, it will
+        simply be discarded with no notification to the completion
+        handler.
+
+        If a connection is established while the stream is destroyed,
+        the peer will see the error `net::error::connection_reset`
+        when performing any reads or writes.
+    */
+    BOOST_BEAST_DECL
+    ~stream();
+
+    /** Move Constructor
+
+        Moving the stream while asynchronous operations are pending
+        results in undefined behavior.
+    */
+    BOOST_BEAST_DECL
+    stream(stream&& other);
+
+    /** Move Assignment
+
+        Moving the stream while asynchronous operations are pending
+        results in undefined behavior.
+    */
+    BOOST_BEAST_DECL
+    stream&
+    operator=(stream&& other);
+
+    /** Construct a stream
+
+        The stream will be created in a disconnected state.
+
+        @param ioc The `io_context` object that the stream will use to
+        dispatch handlers for any asynchronous operations.
+    */
+    BOOST_BEAST_DECL
+    explicit
+    stream(net::io_context& ioc);
+
+    /** Construct a stream
+
+        The stream will be created in a disconnected state.
+
+        @param ioc The `io_context` object that the stream will use to
+        dispatch handlers for any asynchronous operations.
+
+        @param fc The @ref fail_count to associate with the stream.
+        Each I/O operation performed on the stream will increment the
+        fail count.  When the fail count reaches its internal limit,
+        a simulated failure error will be raised.
+    */
+    BOOST_BEAST_DECL
+    stream(
+        net::io_context& ioc,
+        fail_count& fc);
+
+    /** Construct a stream
+
+        The stream will be created in a disconnected state.
+
+        @param ioc The `io_context` object that the stream will use to
+        dispatch handlers for any asynchronous operations.
+
+        @param s A string which will be appended to the input area, not
+        including the null terminator.
+    */
+    BOOST_BEAST_DECL
+    stream(
+        net::io_context& ioc,
+        string_view s);
+
+    /** Construct a stream
+
+        The stream will be created in a disconnected state.
+
+        @param ioc The `io_context` object that the stream will use to
+        dispatch handlers for any asynchronous operations.
+
+        @param fc The @ref fail_count to associate with the stream.
+        Each I/O operation performed on the stream will increment the
+        fail count.  When the fail count reaches its internal limit,
+        a simulated failure error will be raised.
+
+        @param s A string which will be appended to the input area, not
+        including the null terminator.
+    */
+    BOOST_BEAST_DECL
+    stream(
+        net::io_context& ioc,
+        fail_count& fc,
+        string_view s);
+
+    /// Establish a connection
+    BOOST_BEAST_DECL
+    void
+    connect(stream& remote);
+
+    /// The type of the executor associated with the object.
+    using executor_type =
+        net::io_context::executor_type;
+
+    /// Return the executor associated with the object.
+    executor_type
+    get_executor() noexcept
+    {
+        return in_->ioc.get_executor();
+    };
+
+    /// Set the maximum number of bytes returned by read_some
+    void
+    read_size(std::size_t n) noexcept
+    {
+        in_->read_max = n;
+    }
+
+    /// Set the maximum number of bytes returned by write_some
+    void
+    write_size(std::size_t n) noexcept
+    {
+        in_->write_max = n;
+    }
+
+    /// Direct input buffer access
+    buffer_type&
+    buffer() noexcept
+    {
+        return in_->b;
+    }
+
+    /// Returns a string view representing the pending input data
+    BOOST_BEAST_DECL
+    string_view
+    str() const;
+
+    /// Appends a string to the pending input data
+    BOOST_BEAST_DECL
+    void
+    append(string_view s);
+
+    /// Clear the pending input area
+    BOOST_BEAST_DECL
+    void
+    clear();
+
+    /// Return the number of reads
+    std::size_t
+    nread() const noexcept
+    {
+        return in_->nread;
+    }
+
+    /// Return the number of bytes read
+    std::size_t
+    nread_bytes() const noexcept
+    {
+        return in_->nread_bytes;
+    }
+
+    /// Return the number of writes
+    std::size_t
+    nwrite() const noexcept
+    {
+        return in_->nwrite;
+    }
+
+    /// Return the number of bytes written
+    std::size_t
+    nwrite_bytes() const noexcept
+    {
+        return in_->nwrite_bytes;
+    }
+
+    /** Close the stream.
+
+        The other end of the connection will see
+        `error::eof` after reading all the remaining data.
+    */
+    BOOST_BEAST_DECL
+    void
+    close();
+
+    /** Close the other end of the stream.
+
+        This end of the connection will see
+        `error::eof` after reading all the remaining data.
+    */
+    BOOST_BEAST_DECL
+    void
+    close_remote();
+
+    /** Read some data from the stream.
+
+        This function is used to read data from the stream. The function call will
+        block until one or more bytes of data has been read successfully, or until
+        an error occurs.
+
+        @param buffers The buffers into which the data will be read.
+
+        @returns The number of bytes read.
+
+        @throws boost::system::system_error Thrown on failure.
+
+        @note The `read_some` operation may not read all of the requested number of
+        bytes. Consider using the function `net::read` if you need to ensure
+        that the requested amount of data is read before the blocking operation
+        completes.
+    */
+    template<class MutableBufferSequence>
+    std::size_t
+    read_some(MutableBufferSequence const& buffers);
+
+    /** Read some data from the stream.
+
+        This function is used to read data from the stream. The function call will
+        block until one or more bytes of data has been read successfully, or until
+        an error occurs.
+
+        @param buffers The buffers into which the data will be read.
+
+        @param ec Set to indicate what error occurred, if any.
+
+        @returns The number of bytes read.
+
+        @note The `read_some` operation may not read all of the requested number of
+        bytes. Consider using the function `net::read` if you need to ensure
+        that the requested amount of data is read before the blocking operation
+        completes.
+    */
+    template<class MutableBufferSequence>
+    std::size_t
+    read_some(MutableBufferSequence const& buffers,
+        error_code& ec);
+
+    /** Start an asynchronous read.
+
+        This function is used to asynchronously read one or more bytes of data from
+        the stream. The function call always returns immediately.
+
+        @param buffers The buffers into which the data will be read. Although the
+        buffers object may be copied as necessary, ownership of the underlying
+        buffers is retained by the caller, which must guarantee that they remain
+        valid until the handler is called.
+
+        @param handler The completion handler to invoke when the operation
+        completes. The implementation takes ownership of the handler by
+        performing a decay-copy. The equivalent function signature of
+        the handler must be:
+        @code
+        void handler(
+            error_code const& ec,           // Result of operation.
+            std::size_t bytes_transferred   // Number of bytes read.
+        );
+        @endcode
+        Regardless of whether the asynchronous operation completes
+        immediately or not, the handler will not be invoked from within
+        this function. Invocation of the handler will be performed in a
+        manner equivalent to using `net::post`.
+
+        @note The `async_read_some` operation may not read all of the requested number of
+        bytes. Consider using the function `net::async_read` if you need
+        to ensure that the requested amount of data is read before the asynchronous
+        operation completes.
+    */
+    template<
+        class MutableBufferSequence,
+        BOOST_BEAST_ASYNC_TPARAM2 ReadHandler>
+    BOOST_BEAST_ASYNC_RESULT2(ReadHandler)
+    async_read_some(
+        MutableBufferSequence const& buffers,
+        ReadHandler&& handler);
+
+    /** Write some data to the stream.
+
+        This function is used to write data on the stream. The function call will
+        block until one or more bytes of data has been written successfully, or
+        until an error occurs.
+
+        @param buffers The data to be written.
+
+        @returns The number of bytes written.
+
+        @throws boost::system::system_error Thrown on failure.
+
+        @note The `write_some` operation may not transmit all of the data to the
+        peer. Consider using the function `net::write` if you need to
+        ensure that all data is written before the blocking operation completes.
+    */
+    template<class ConstBufferSequence>
+    std::size_t
+    write_some(ConstBufferSequence const& buffers);
+
+    /** Write some data to the stream.
+
+        This function is used to write data on the stream. The function call will
+        block until one or more bytes of data has been written successfully, or
+        until an error occurs.
+
+        @param buffers The data to be written.
+
+        @param ec Set to indicate what error occurred, if any.
+
+        @returns The number of bytes written.
+
+        @note The `write_some` operation may not transmit all of the data to the
+        peer. Consider using the function `net::write` if you need to
+        ensure that all data is written before the blocking operation completes.
+    */
+    template<class ConstBufferSequence>
+    std::size_t
+    write_some(
+        ConstBufferSequence const& buffers, error_code& ec);
+
+    /** Start an asynchronous write.
+
+        This function is used to asynchronously write one or more bytes of data to
+        the stream. The function call always returns immediately.
+
+        @param buffers The data to be written to the stream. Although the buffers
+        object may be copied as necessary, ownership of the underlying buffers is
+        retained by the caller, which must guarantee that they remain valid until
+        the handler is called.
+
+        @param handler The completion handler to invoke when the operation
+        completes. The implementation takes ownership of the handler by
+        performing a decay-copy. The equivalent function signature of
+        the handler must be:
+        @code
+        void handler(
+            error_code const& ec,           // Result of operation.
+            std::size_t bytes_transferred   // Number of bytes written.
+        );
+        @endcode
+        Regardless of whether the asynchronous operation completes
+        immediately or not, the handler will not be invoked from within
+        this function. Invocation of the handler will be performed in a
+        manner equivalent to using `net::post`.
+
+        @note The `async_write_some` operation may not transmit all of the data to
+        the peer. Consider using the function `net::async_write` if you need
+        to ensure that all data is written before the asynchronous operation completes.
+    */
+    template<
+        class ConstBufferSequence,
+        BOOST_BEAST_ASYNC_TPARAM2 WriteHandler>
+    BOOST_BEAST_ASYNC_RESULT2(WriteHandler)
+    async_write_some(
+        ConstBufferSequence const& buffers,
+        WriteHandler&& handler);
+
+#if ! BOOST_BEAST_DOXYGEN
+    friend
+    BOOST_BEAST_DECL
+    void
+    teardown(
+        role_type,
+        stream& s,
+        boost::system::error_code& ec);
+
+    template<class TeardownHandler>
+    friend
+    BOOST_BEAST_DECL
+    void
+    async_teardown(
+        role_type role,
+        stream& s,
+        TeardownHandler&& handler);
+#endif
+};
+
+#if ! BOOST_BEAST_DOXYGEN
+inline
+void
+beast_close_socket(stream& s)
+{
+    s.close();
+}
+#endif
+
+#if BOOST_BEAST_DOXYGEN
+/** Return a new stream connected to the given stream
+
+    @param to The stream to connect to.
+
+    @param args Optional arguments forwarded to the new stream's constructor.
+
+    @return The new, connected stream.
+*/
+template<class... Args>
+stream
+connect(stream& to, Args&&... args);
+
+#else
+BOOST_BEAST_DECL
+stream
+connect(stream& to);
+
+BOOST_BEAST_DECL
+void
+connect(stream& s1, stream& s2);
+
+template<class Arg1, class... ArgN>
+stream
+connect(stream& to, Arg1&& arg1, ArgN&&... argn);
+#endif
+
+} // test
+} // beast
+} // boost
+
+#include <boost/beast/_experimental/test/impl/stream.hpp>
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/_experimental/test/impl/stream.ipp>
+#endif
+
+#endif

--- a/test/utils/stream.hpp
+++ b/test/utils/stream.hpp
@@ -38,8 +38,8 @@
 #include <string_view>
 using string_view = std::string_view;
 #else
-#include <boost/utility/string_view.hpp>
-using string_view = boost::string_view;
+#include "impl/string_view.hpp"
+using string_view = nonstd::string_view;
 #endif
 
 #ifdef WINTLS_USE_STANDALONE_ASIO

--- a/test/utils/subprocess.h
+++ b/test/utils/subprocess.h
@@ -1,0 +1,1184 @@
+/*
+   The latest version of this library is available on GitHub;
+   https://github.com/sheredom/subprocess.h
+*/
+
+/*
+   This is free and unencumbered software released into the public domain.
+
+   Anyone is free to copy, modify, publish, use, compile, sell, or
+   distribute this software, either in source code form or as a compiled
+   binary, for any purpose, commercial or non-commercial, and by any
+   means.
+
+   In jurisdictions that recognize copyright laws, the author or authors
+   of this software dedicate any and all copyright interest in the
+   software to the public domain. We make this dedication for the benefit
+   of the public at large and to the detriment of our heirs and
+   successors. We intend this dedication to be an overt act of
+   relinquishment in perpetuity of all present and future rights to this
+   software under copyright law.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+
+   For more information, please refer to <http://unlicense.org/>
+*/
+
+#ifndef SHEREDOM_SUBPROCESS_H_INCLUDED
+#define SHEREDOM_SUBPROCESS_H_INCLUDED
+
+#if defined(_MSC_VER)
+#pragma warning(push, 1)
+
+/* disable warning: '__cplusplus' is not defined as a preprocessor macro,
+ * replacing with '0' for '#if/#elif' */
+#pragma warning(disable : 4668)
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#if defined(_MSC_VER)
+#define subprocess_pure
+#define subprocess_weak __inline
+#define subprocess_tls __declspec(thread)
+#elif defined(__MINGW32__)
+#define subprocess_pure __attribute__((pure))
+#define subprocess_weak static __attribute__((used))
+#define subprocess_tls __thread
+#elif defined(__clang__) || defined(__GNUC__)
+#define subprocess_pure __attribute__((pure))
+#define subprocess_weak __attribute__((weak))
+#define subprocess_tls __thread
+#else
+#error Non clang, non gcc, non MSVC compiler found!
+#endif
+
+struct subprocess_s;
+
+enum subprocess_option_e {
+  // stdout and stderr are the same FILE.
+  subprocess_option_combined_stdout_stderr = 0x1,
+
+  // The child process should inherit the environment variables of the parent.
+  subprocess_option_inherit_environment = 0x2,
+
+  // Enable asynchronous reading of stdout/stderr before it has completed.
+  subprocess_option_enable_async = 0x4,
+
+  // Enable the child process to be spawned with no window visible if supported
+  // by the platform.
+  subprocess_option_no_window = 0x8,
+
+  // Search for program names in the PATH variable. Always enabled on Windows.
+  // Note: this will **not** search for paths in any provided custom environment
+  // and instead uses the PATH of the spawning process.
+  subprocess_option_search_user_path = 0x10
+};
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/// @brief Create a process.
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+subprocess_weak int subprocess_create(const char *const command_line[],
+                                      int options,
+                                      struct subprocess_s *const out_process);
+
+/// @brief Create a process (extended create).
+/// @param command_line An array of strings for the command line to execute for
+/// this process. The last element must be NULL to signify the end of the array.
+/// The memory backing this parameter only needs to persist until this function
+/// returns.
+/// @param options A bit field of subprocess_option_e's to pass.
+/// @param environment An optional array of strings for the environment to use
+/// for a child process (each element of the form FOO=BAR). The last element
+/// must be NULL to signify the end of the array.
+/// @param out_process The newly created process.
+/// @return On success zero is returned.
+///
+/// If `options` contains `subprocess_option_inherit_environment`, then
+/// `environment` must be NULL.
+subprocess_weak int
+subprocess_create_ex(const char *const command_line[], int options,
+                     const char *const environment[],
+                     struct subprocess_s *const out_process);
+
+/// @brief Get the standard input file for a process.
+/// @param process The process to query.
+/// @return The file for standard input of the process.
+///
+/// The file returned can be written to by the parent process to feed data to
+/// the standard input of the process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdin(const struct subprocess_s *const process);
+
+/// @brief Get the standard output file for a process.
+/// @param process The process to query.
+/// @return The file for standard output of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard output of the child process.
+subprocess_pure subprocess_weak FILE *
+subprocess_stdout(const struct subprocess_s *const process);
+
+/// @brief Get the standard error file for a process.
+/// @param process The process to query.
+/// @return The file for standard error of the process.
+///
+/// The file returned can be read from by the parent process to read data from
+/// the standard error of the child process.
+///
+/// If the process was created with the subprocess_option_combined_stdout_stderr
+/// option bit set, this function will return NULL, and the subprocess_stdout
+/// function should be used for both the standard output and error combined.
+subprocess_pure subprocess_weak FILE *
+subprocess_stderr(const struct subprocess_s *const process);
+
+/// @brief Wait for a process to finish execution.
+/// @param process The process to wait for.
+/// @param out_return_code The return code of the returned process (can be
+/// NULL).
+/// @return On success zero is returned.
+///
+/// Joining a process will close the stdin pipe to the process.
+subprocess_weak int subprocess_join(struct subprocess_s *const process,
+                                    int *const out_return_code);
+
+/// @brief Destroy a previously created process.
+/// @param process The process to destroy.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it may out live
+/// the parent process.
+subprocess_weak int subprocess_destroy(struct subprocess_s *const process);
+
+/// @brief Terminate a previously created process.
+/// @param process The process to terminate.
+/// @return On success zero is returned.
+///
+/// If the process to be destroyed had not finished execution, it will be
+/// terminated (i.e killed).
+subprocess_weak int subprocess_terminate(struct subprocess_s *const process);
+
+/// @brief Read the standard output from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard output of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjuction with this method.
+subprocess_weak unsigned
+subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Read the standard error from the child process.
+/// @param process The process to read from.
+/// @param buffer The buffer to read into.
+/// @param size The maximum number of bytes to read.
+/// @return The number of bytes actually read into buffer. Can only be 0 if the
+/// process has complete.
+///
+/// The only safe way to read from the standard error of a process during it's
+/// execution is to use the `subprocess_option_enable_async` option in
+/// conjuction with this method.
+subprocess_weak unsigned
+subprocess_read_stderr(struct subprocess_s *const process, char *const buffer,
+                       unsigned size);
+
+/// @brief Returns if the subprocess is currently still alive and executing.
+/// @param process The process to check.
+/// @return If the process is still alive non-zero is returned.
+subprocess_weak int subprocess_alive(struct subprocess_s *const process);
+
+#if defined(__cplusplus)
+#define SUBPROCESS_CAST(type, x) static_cast<type>(x)
+#define SUBPROCESS_PTR_CAST(type, x) reinterpret_cast<type>(x)
+#define SUBPROCESS_CONST_CAST(type, x) const_cast<type>(x)
+#define SUBPROCESS_NULL NULL
+#else
+#define SUBPROCESS_CAST(type, x) ((type)(x))
+#define SUBPROCESS_PTR_CAST(type, x) ((type)(x))
+#define SUBPROCESS_CONST_CAST(type, x) ((type)(x))
+#define SUBPROCESS_NULL 0
+#endif
+
+#if !defined(_WIN32)
+#include <signal.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#if defined(_WIN32)
+
+#if (_MSC_VER < 1920)
+#ifdef _WIN64
+typedef __int64 subprocess_intptr_t;
+typedef unsigned __int64 subprocess_size_t;
+#else
+typedef int subprocess_intptr_t;
+typedef unsigned int subprocess_size_t;
+#endif
+#else
+#include <inttypes.h>
+
+typedef intptr_t subprocess_intptr_t;
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#if __has_warning("-Wreserved-identifier")
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+#endif
+
+typedef struct _PROCESS_INFORMATION *LPPROCESS_INFORMATION;
+typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
+typedef struct _STARTUPINFOA *LPSTARTUPINFOA;
+typedef struct _OVERLAPPED *LPOVERLAPPED;
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push, 1)
+#endif
+#ifdef __MINGW32__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+struct subprocess_subprocess_information_s {
+  void *hProcess;
+  void *hThread;
+  unsigned long dwProcessId;
+  unsigned long dwThreadId;
+};
+
+struct subprocess_security_attributes_s {
+  unsigned long nLength;
+  void *lpSecurityDescriptor;
+  int bInheritHandle;
+};
+
+struct subprocess_startup_info_s {
+  unsigned long cb;
+  char *lpReserved;
+  char *lpDesktop;
+  char *lpTitle;
+  unsigned long dwX;
+  unsigned long dwY;
+  unsigned long dwXSize;
+  unsigned long dwYSize;
+  unsigned long dwXCountChars;
+  unsigned long dwYCountChars;
+  unsigned long dwFillAttribute;
+  unsigned long dwFlags;
+  unsigned short wShowWindow;
+  unsigned short cbReserved2;
+  unsigned char *lpReserved2;
+  void *hStdInput;
+  void *hStdOutput;
+  void *hStdError;
+};
+
+struct subprocess_overlapped_s {
+  uintptr_t Internal;
+  uintptr_t InternalHigh;
+  union {
+    struct {
+      unsigned long Offset;
+      unsigned long OffsetHigh;
+    } DUMMYSTRUCTNAME;
+    void *Pointer;
+  } DUMMYUNIONNAME;
+
+  void *hEvent;
+};
+
+#ifdef __MINGW32__
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+__declspec(dllimport) unsigned long __stdcall GetLastError(void);
+__declspec(dllimport) int __stdcall SetHandleInformation(void *, unsigned long,
+                                                         unsigned long);
+__declspec(dllimport) int __stdcall CreatePipe(void **, void **,
+                                               LPSECURITY_ATTRIBUTES,
+                                               unsigned long);
+__declspec(dllimport) void *__stdcall CreateNamedPipeA(
+    const char *, unsigned long, unsigned long, unsigned long, unsigned long,
+    unsigned long, unsigned long, LPSECURITY_ATTRIBUTES);
+__declspec(dllimport) int __stdcall ReadFile(void *, void *, unsigned long,
+                                             unsigned long *, LPOVERLAPPED);
+__declspec(dllimport) unsigned long __stdcall GetCurrentProcessId(void);
+__declspec(dllimport) unsigned long __stdcall GetCurrentThreadId(void);
+__declspec(dllimport) void *__stdcall CreateFileA(const char *, unsigned long,
+                                                  unsigned long,
+                                                  LPSECURITY_ATTRIBUTES,
+                                                  unsigned long, unsigned long,
+                                                  void *);
+__declspec(dllimport) void *__stdcall CreateEventA(LPSECURITY_ATTRIBUTES, int,
+                                                   int, const char *);
+__declspec(dllimport) int __stdcall CreateProcessA(
+    const char *, char *, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, int,
+    unsigned long, void *, const char *, LPSTARTUPINFOA, LPPROCESS_INFORMATION);
+__declspec(dllimport) int __stdcall CloseHandle(void *);
+__declspec(dllimport) unsigned long __stdcall WaitForSingleObject(
+    void *, unsigned long);
+__declspec(dllimport) int __stdcall GetExitCodeProcess(
+    void *, unsigned long *lpExitCode);
+__declspec(dllimport) int __stdcall TerminateProcess(void *, unsigned int);
+__declspec(dllimport) unsigned long __stdcall WaitForMultipleObjects(
+    unsigned long, void *const *, int, unsigned long);
+__declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
+                                                        unsigned long *, int);
+
+#if defined(_DLL)
+#define SUBPROCESS_DLLIMPORT __declspec(dllimport)
+#else
+#define SUBPROCESS_DLLIMPORT
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#if __has_warning("-Wreserved-identifier")
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+#endif
+
+SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
+SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
+SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+
+#ifndef __MINGW32__
+void *__cdecl _alloca(subprocess_size_t);
+#else
+#include <malloc.h>
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#else
+typedef size_t subprocess_size_t;
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+struct subprocess_s {
+  FILE *stdin_file;
+  FILE *stdout_file;
+  FILE *stderr_file;
+
+#if defined(_WIN32)
+  void *hProcess;
+  void *hStdInput;
+  void *hEventOutput;
+  void *hEventError;
+#else
+  pid_t child;
+  int return_status;
+#endif
+
+  subprocess_size_t alive;
+};
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#if defined(_WIN32)
+subprocess_weak int subprocess_create_named_pipe_helper(void **rd, void **wr);
+int subprocess_create_named_pipe_helper(void **rd, void **wr) {
+  const unsigned long pipeAccessInbound = 0x00000001;
+  const unsigned long fileFlagOverlapped = 0x40000000;
+  const unsigned long pipeTypeByte = 0x00000000;
+  const unsigned long pipeWait = 0x00000000;
+  const unsigned long genericWrite = 0x40000000;
+  const unsigned long openExisting = 3;
+  const unsigned long fileAttributeNormal = 0x00000080;
+  const void *const invalidHandleValue =
+      SUBPROCESS_PTR_CAST(void *, ~(SUBPROCESS_CAST(subprocess_intptr_t, 0)));
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char name[256] = {0};
+  static subprocess_tls long index = 0;
+  const long unique = index++;
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#pragma warning(push, 1)
+#pragma warning(disable : 4996)
+  _snprintf(name, sizeof(name) - 1,
+            "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+            GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#pragma warning(pop)
+#else
+  snprintf(name, sizeof(name) - 1,
+           "\\\\.\\pipe\\sheredom_subprocess_h.%08lx.%08lx.%ld",
+           GetCurrentProcessId(), GetCurrentThreadId(), unique);
+#endif
+
+  *rd =
+      CreateNamedPipeA(name, pipeAccessInbound | fileFlagOverlapped,
+                       pipeTypeByte | pipeWait, 1, 4096, 4096, SUBPROCESS_NULL,
+                       SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr));
+
+  if (invalidHandleValue == *rd) {
+    return -1;
+  }
+
+  *wr = CreateFileA(name, genericWrite, SUBPROCESS_NULL,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                    openExisting, fileAttributeNormal, SUBPROCESS_NULL);
+
+  if (invalidHandleValue == *wr) {
+    return -1;
+  }
+
+  return 0;
+}
+#endif
+
+int subprocess_create(const char *const commandLine[], int options,
+                      struct subprocess_s *const out_process) {
+  return subprocess_create_ex(commandLine, options, SUBPROCESS_NULL,
+                              out_process);
+}
+
+int subprocess_create_ex(const char *const commandLine[], int options,
+                         const char *const environment[],
+                         struct subprocess_s *const out_process) {
+#if defined(_WIN32)
+  int fd;
+  void *rd, *wr;
+  char *commandLineCombined;
+  subprocess_size_t len;
+  int i, j;
+  int need_quoting;
+  unsigned long flags = 0;
+  const unsigned long startFUseStdHandles = 0x00000100;
+  const unsigned long handleFlagInherit = 0x00000001;
+  const unsigned long createNoWindow = 0x08000000;
+  struct subprocess_subprocess_information_s processInfo;
+  struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
+                                                    SUBPROCESS_NULL, 1};
+  char *used_environment = SUBPROCESS_NULL;
+  struct subprocess_startup_info_s startInfo = {0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                0,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL,
+                                                SUBPROCESS_NULL};
+
+  startInfo.cb = sizeof(startInfo);
+  startInfo.dwFlags = startFUseStdHandles;
+
+  if (subprocess_option_no_window == (options & subprocess_option_no_window)) {
+    flags |= createNoWindow;
+  }
+
+  if (subprocess_option_inherit_environment !=
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL == environment) {
+      used_environment = SUBPROCESS_CONST_CAST(char *, "\0\0");
+    } else {
+      // We always end with two null terminators.
+      len = 2;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          len++;
+        }
+
+        // For the null terminator too.
+        len++;
+      }
+
+      used_environment = SUBPROCESS_CAST(char *, _alloca(len));
+
+      // Re-use len for the insertion position
+      len = 0;
+
+      for (i = 0; environment[i]; i++) {
+        for (j = 0; '\0' != environment[i][j]; j++) {
+          used_environment[len++] = environment[i][j];
+        }
+
+        used_environment[len++] = '\0';
+      }
+
+      // End with the two null terminators.
+      used_environment[len++] = '\0';
+      used_environment[len++] = '\0';
+    }
+  } else {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (!CreatePipe(&rd, &wr, SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
+                  0)) {
+    return -1;
+  }
+
+  if (!SetHandleInformation(wr, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, wr), 0);
+
+  if (-1 != fd) {
+    out_process->stdin_file = _fdopen(fd, "wb");
+
+    if (SUBPROCESS_NULL == out_process->stdin_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdInput = rd;
+
+  if (options & subprocess_option_enable_async) {
+    if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+      return -1;
+    }
+  } else {
+    if (!CreatePipe(&rd, &wr,
+                    SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+      return -1;
+    }
+  }
+
+  if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+    return -1;
+  }
+
+  fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+  if (-1 != fd) {
+    out_process->stdout_file = _fdopen(fd, "rb");
+
+    if (SUBPROCESS_NULL == out_process->stdout_file) {
+      return -1;
+    }
+  }
+
+  startInfo.hStdOutput = wr;
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+    startInfo.hStdError = startInfo.hStdOutput;
+  } else {
+    if (options & subprocess_option_enable_async) {
+      if (subprocess_create_named_pipe_helper(&rd, &wr)) {
+        return -1;
+      }
+    } else {
+      if (!CreatePipe(&rd, &wr,
+                      SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
+        return -1;
+      }
+    }
+
+    if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
+      return -1;
+    }
+
+    fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+
+    if (-1 != fd) {
+      out_process->stderr_file = _fdopen(fd, "rb");
+
+      if (SUBPROCESS_NULL == out_process->stderr_file) {
+        return -1;
+      }
+    }
+
+    startInfo.hStdError = wr;
+  }
+
+  if (options & subprocess_option_enable_async) {
+    out_process->hEventOutput =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+    out_process->hEventError =
+        CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
+                     SUBPROCESS_NULL);
+  } else {
+    out_process->hEventOutput = SUBPROCESS_NULL;
+    out_process->hEventError = SUBPROCESS_NULL;
+  }
+
+  // Combine commandLine together into a single string
+  len = 0;
+  for (i = 0; commandLine[i]; i++) {
+    // for the trailing \0
+    len++;
+
+    // Quote the argument if it has a space in it
+    if (strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL)
+      len += 2;
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          len++;
+        }
+
+        break;
+      case '"':
+        len++;
+        break;
+      }
+      len++;
+    }
+  }
+
+  commandLineCombined = SUBPROCESS_CAST(char *, _alloca(len));
+
+  if (!commandLineCombined) {
+    return -1;
+  }
+
+  // Gonna re-use len to store the write index into commandLineCombined
+  len = 0;
+
+  for (i = 0; commandLine[i]; i++) {
+    if (0 != i) {
+      commandLineCombined[len++] = ' ';
+    }
+
+    need_quoting = strpbrk(commandLine[i], "\t\v ") != SUBPROCESS_NULL;
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+
+    for (j = 0; '\0' != commandLine[i][j]; j++) {
+      switch (commandLine[i][j]) {
+      default:
+        break;
+      case '\\':
+        if (commandLine[i][j + 1] == '"') {
+          commandLineCombined[len++] = '\\';
+        }
+
+        break;
+      case '"':
+        commandLineCombined[len++] = '\\';
+        break;
+      }
+
+      commandLineCombined[len++] = commandLine[i][j];
+    }
+    if (need_quoting) {
+      commandLineCombined[len++] = '"';
+    }
+  }
+
+  commandLineCombined[len] = '\0';
+
+  if (!CreateProcessA(
+          SUBPROCESS_NULL,
+          commandLineCombined, // command line
+          SUBPROCESS_NULL,     // process security attributes
+          SUBPROCESS_NULL,     // primary thread security attributes
+          1,                   // handles are inherited
+          flags,               // creation flags
+          used_environment,    // used environment
+          SUBPROCESS_NULL,     // use parent's current directory
+          SUBPROCESS_PTR_CAST(LPSTARTUPINFOA,
+                              &startInfo), // STARTUPINFO pointer
+          SUBPROCESS_PTR_CAST(LPPROCESS_INFORMATION, &processInfo))) {
+    return -1;
+  }
+
+  out_process->hProcess = processInfo.hProcess;
+
+  out_process->hStdInput = startInfo.hStdInput;
+
+  // We don't need the handle of the primary thread in the called process.
+  CloseHandle(processInfo.hThread);
+
+  if (SUBPROCESS_NULL != startInfo.hStdOutput) {
+    CloseHandle(startInfo.hStdOutput);
+
+    if (startInfo.hStdError != startInfo.hStdOutput) {
+      CloseHandle(startInfo.hStdError);
+    }
+  }
+
+  out_process->alive = 1;
+
+  return 0;
+#else
+  int stdinfd[2];
+  int stdoutfd[2];
+  int stderrfd[2];
+  pid_t child;
+  extern char **environ;
+  char *const empty_environment[1] = {SUBPROCESS_NULL};
+  posix_spawn_file_actions_t actions;
+  char *const *used_environment;
+
+  if (subprocess_option_inherit_environment ==
+      (options & subprocess_option_inherit_environment)) {
+    if (SUBPROCESS_NULL != environment) {
+      return -1;
+    }
+  }
+
+  if (0 != pipe(stdinfd)) {
+    return -1;
+  }
+
+  if (0 != pipe(stdoutfd)) {
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr !=
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != pipe(stderrfd)) {
+      return -1;
+    }
+  }
+
+  if (environment) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+    used_environment = (char *const *)environment;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  } else if (subprocess_option_inherit_environment ==
+             (options & subprocess_option_inherit_environment)) {
+    used_environment = environ;
+  } else {
+    used_environment = empty_environment;
+  }
+
+  if (0 != posix_spawn_file_actions_init(&actions)) {
+    return -1;
+  }
+
+  // Close the stdin write end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdinfd[1])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the read end to stdin
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Close the stdout read end
+  if (0 != posix_spawn_file_actions_addclose(&actions, stdoutfd[0])) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  // Map the write end to stdout
+  if (0 !=
+      posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO)) {
+    posix_spawn_file_actions_destroy(&actions);
+    return -1;
+  }
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    if (0 != posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    // Close the stderr read end
+    if (0 != posix_spawn_file_actions_addclose(&actions, stderrfd[0])) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+    // Map the write end to stdout
+    if (0 != posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
+                                              STDERR_FILENO)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
+  if (subprocess_option_search_user_path ==
+      (options & subprocess_option_search_user_path)) {
+    if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                          (char *const *)commandLine, used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  } else {
+    if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
+                         (char *const *)commandLine, used_environment)) {
+      posix_spawn_file_actions_destroy(&actions);
+      return -1;
+    }
+  }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+  // Close the stdin read end
+  close(stdinfd[0]);
+  // Store the stdin write end
+  out_process->stdin_file = fdopen(stdinfd[1], "wb");
+
+  // Close the stdout write end
+  close(stdoutfd[1]);
+  // Store the stdout read end
+  out_process->stdout_file = fdopen(stdoutfd[0], "rb");
+
+  if (subprocess_option_combined_stdout_stderr ==
+      (options & subprocess_option_combined_stdout_stderr)) {
+    out_process->stderr_file = out_process->stdout_file;
+  } else {
+    // Close the stderr write end
+    close(stderrfd[1]);
+    // Store the stderr read end
+    out_process->stderr_file = fdopen(stderrfd[0], "rb");
+  }
+
+  // Store the child's pid
+  out_process->child = child;
+
+  out_process->alive = 1;
+
+  posix_spawn_file_actions_destroy(&actions);
+  return 0;
+#endif
+}
+
+FILE *subprocess_stdin(const struct subprocess_s *const process) {
+  return process->stdin_file;
+}
+
+FILE *subprocess_stdout(const struct subprocess_s *const process) {
+  return process->stdout_file;
+}
+
+FILE *subprocess_stderr(const struct subprocess_s *const process) {
+  if (process->stdout_file != process->stderr_file) {
+    return process->stderr_file;
+  } else {
+    return SUBPROCESS_NULL;
+  }
+}
+
+int subprocess_join(struct subprocess_s *const process,
+                    int *const out_return_code) {
+#if defined(_WIN32)
+  const unsigned long infinite = 0xFFFFFFFF;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->hStdInput) {
+    CloseHandle(process->hStdInput);
+    process->hStdInput = SUBPROCESS_NULL;
+  }
+
+  WaitForSingleObject(process->hProcess, infinite);
+
+  if (out_return_code) {
+    if (!GetExitCodeProcess(
+            process->hProcess,
+            SUBPROCESS_PTR_CAST(unsigned long *, out_return_code))) {
+      return -1;
+    }
+  }
+
+  process->alive = 0;
+
+  return 0;
+#else
+  int status;
+
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->child) {
+    if (process->child != waitpid(process->child, &status, 0)) {
+      return -1;
+    }
+
+    process->child = 0;
+
+    if (WIFEXITED(status)) {
+      process->return_status = WEXITSTATUS(status);
+    } else {
+      process->return_status = EXIT_FAILURE;
+    }
+
+    process->alive = 0;
+  }
+
+  if (out_return_code) {
+    *out_return_code = process->return_status;
+  }
+
+  return 0;
+#endif
+}
+
+int subprocess_destroy(struct subprocess_s *const process) {
+  if (process->stdin_file) {
+    fclose(process->stdin_file);
+    process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (process->stdout_file) {
+    fclose(process->stdout_file);
+
+    if (process->stdout_file != process->stderr_file) {
+      fclose(process->stderr_file);
+    }
+
+    process->stdout_file = SUBPROCESS_NULL;
+    process->stderr_file = SUBPROCESS_NULL;
+  }
+
+#if defined(_WIN32)
+  if (process->hProcess) {
+    CloseHandle(process->hProcess);
+    process->hProcess = SUBPROCESS_NULL;
+
+    if (process->hStdInput) {
+      CloseHandle(process->hStdInput);
+    }
+
+    if (process->hEventOutput) {
+      CloseHandle(process->hEventOutput);
+    }
+
+    if (process->hEventError) {
+      CloseHandle(process->hEventError);
+    }
+  }
+#endif
+
+  return 0;
+}
+
+int subprocess_terminate(struct subprocess_s *const process) {
+#if defined(_WIN32)
+  unsigned int killed_process_exit_code;
+  int success_terminate;
+  int windows_call_result;
+
+  killed_process_exit_code = 99;
+  windows_call_result =
+      TerminateProcess(process->hProcess, killed_process_exit_code);
+  success_terminate = (windows_call_result == 0) ? 1 : 0;
+  return success_terminate;
+#else
+  int result;
+  result = kill(process->child, 9);
+  return result;
+#endif
+}
+
+unsigned subprocess_read_stdout(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventOutput;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stdout_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stdout_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+unsigned subprocess_read_stderr(struct subprocess_s *const process,
+                                char *const buffer, unsigned size) {
+#if defined(_WIN32)
+  void *handle;
+  unsigned long bytes_read = 0;
+  struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
+  overlapped.hEvent = process->hEventError;
+
+  handle = SUBPROCESS_PTR_CAST(void *,
+                               _get_osfhandle(_fileno(process->stderr_file)));
+
+  if (!ReadFile(handle, buffer, size, &bytes_read,
+                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
+    const unsigned long errorIoPending = 997;
+    unsigned long error = GetLastError();
+
+    // Means we've got an async read!
+    if (error == errorIoPending) {
+      if (!GetOverlappedResult(handle,
+                               SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
+                               &bytes_read, 1)) {
+        const unsigned long errorIoIncomplete = 996;
+        const unsigned long errorHandleEOF = 38;
+        error = GetLastError();
+
+        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#else
+  const int fd = fileno(process->stderr_file);
+  const ssize_t bytes_read = read(fd, buffer, size);
+
+  if (bytes_read < 0) {
+    return 0;
+  }
+
+  return SUBPROCESS_CAST(unsigned, bytes_read);
+#endif
+}
+
+int subprocess_alive(struct subprocess_s *const process) {
+  int is_alive = SUBPROCESS_CAST(int, process->alive);
+
+  if (!is_alive) {
+    return 0;
+  }
+#if defined(_WIN32)
+  {
+    const unsigned long zero = 0x0;
+    const unsigned long wait_object_0 = 0x00000000L;
+
+    is_alive = wait_object_0 != WaitForSingleObject(process->hProcess, zero);
+  }
+#else
+  {
+    int status;
+    is_alive = 0 == waitpid(process->child, &status, WNOHANG);
+
+    // If the process was successfully waited on we need to cleanup now.
+    if (!is_alive) {
+      if (WIFEXITED(status)) {
+        process->return_status = WEXITSTATUS(status);
+      } else {
+        process->return_status = EXIT_FAILURE;
+      }
+
+      // Since we've already successfully waited on the process, we need to wipe
+      // the child now.
+      process->child = 0;
+
+      if (subprocess_join(process, SUBPROCESS_NULL)) {
+        return -1;
+      }
+    }
+  }
+#endif
+
+  if (!is_alive) {
+    process->alive = 0;
+  }
+
+  return is_alive;
+}
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif /* SHEREDOM_SUBPROCESS_H_INCLUDED */

--- a/test/wintls_client_stream.hpp
+++ b/test/wintls_client_stream.hpp
@@ -35,7 +35,7 @@ struct wintls_client_context : public boost::wintls::context {
     with_test_cert_authority();
 
     // delete key in case last test run has dangling key.
-    boost::system::error_code dummy;
+    error_code dummy;
     boost::wintls::delete_private_key(test_key_name_client, dummy);
 
     boost::wintls::import_private_key(net::buffer(test_key), boost::wintls::file_format::pem, test_key_name_client);

--- a/test/wintls_server_stream.hpp
+++ b/test/wintls_server_stream.hpp
@@ -19,7 +19,7 @@ struct wintls_server_context : public boost::wintls::context {
     : boost::wintls::context(boost::wintls::method::system_default)
     , needs_private_key_clean_up_(false) {
       // delete key in case last test run has dangling key.
-      boost::system::error_code dummy;
+      error_code dummy;
       boost::wintls::delete_private_key(test_key_name_server, dummy);
 
       auto cert_ptr = x509_to_cert_context(net::buffer(test_certificate), boost::wintls::file_format::pem);


### PR DESCRIPTION
Hi, @laudrup

As we discussed in #79 , the pr is a simple attempt to add support for the non-boost version of wintls. It only contains modifications to the core code, excluding build system and test code. This is still a crude attempt, but should be sufficient for the header only version.

The main tricks are contained in `config.hpp`. Use C++ using alias to distinguish boost and non-boost versions, and use the `WINTLS_USE_STANDALONE_ASIO` macro to control whether to use the boost version.  Some boost functions and macros for assertions have been rewritten, and currently we don't depend on any boost components.

As you say, beast currently depends on boost-asio.  So in my opinion, if we use a library like beast, we can just use the boost version of winstl. Well, I'm not sure if there will be a problem mixing boost-asio with standalone-asio in beast.

There's definitely a lot that can be improved here. Looking forward to your review, thanks!
