### PR TITLE
Add support for Beast WebSockets

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -2,6 +2,11 @@
 name: unittest
 on: [push, pull_request]
 
+# stop in-progress builds on push
+concurrency:
+  group: unittest-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unittest-boost-asio:
     name: "${{matrix.generator}} ${{matrix.toolset}} Boost ${{matrix.boost_version}} ${{matrix.build_type}} C++${{matrix.standard}} ${{matrix.name_args}}"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -52,7 +52,7 @@ jobs:
             toolset: ""
             build_type: ""
             generator: "MinGW Makefiles"
-            config_args: "-DOPENSSL_ROOT_DIR=\"c:/Program Files/OpenSSL\""
+            config_args: ""
             name_args: ""
 
     steps:
@@ -126,6 +126,7 @@ jobs:
               "${GITHUB_WORKSPACE}"
       env:
         BOOST_ROOT: ${{env.BOOST_INSTALL_PATH}}/boost
+        OPENSSL_ROOT: ${{matrix.generator == 'MinGW Makefiles' && 'C:/Program Files/OpenSSL' || null}}
 
     - name: Build
       working-directory: build

--- a/doc/async_websocket_client.rst
+++ b/doc/async_websocket_client.rst
@@ -1,0 +1,9 @@
+Asynchronous WebSocket Client
+-------------------------
+This example demonstrates a basic asynchronous WebSocket client using
+`boost::beast`_.
+
+.. literalinclude:: ../examples/async_websocket_client.cpp
+   :lines: 7-
+
+.. _boost::beast: https://github.com/boostorg/beast

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -12,3 +12,5 @@ Examples
    async_https_client
    echo_client
    echo_server
+   websocket_client
+   async_websocket_client

--- a/doc/websocket_client.rst
+++ b/doc/websocket_client.rst
@@ -1,0 +1,9 @@
+WebSocket Client
+------------
+This example demonstrates a basic synchronous WebSocket client using
+`boost::beast`_.
+
+.. literalinclude:: ../examples/websocket_client.cpp
+   :lines: 7-
+
+.. _boost::beast: https://github.com/boostorg/beast

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,8 @@ if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       # Temporary workaround issue https://github.com/boostorg/beast/issues/1582
       target_compile_options(${name} PRIVATE "-wd4702")
+      # Object files get quite big when using async and beast
+      target_compile_options(${name} PRIVATE "/bigobj")
     endif()
 
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -37,4 +39,6 @@ if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
 
   add_wintls_example(https_client)
   add_wintls_example(async_https_client)
+  add_wintls_example(websocket_client)
+  add_wintls_example(async_websocket_client)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,32 +15,26 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
-  add_executable(https_client https_client.cpp)
-  add_executable(async_https_client async_https_client.cpp)
+  function(add_wintls_example name)
+    add_executable(${name} ${name}.cpp)
+    target_link_libraries(${name} PRIVATE wintls)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      # Temporary workaround issue https://github.com/boostorg/beast/issues/1582
+      target_compile_options(${name} PRIVATE "-wd4702")
+    endif()
 
-  target_link_libraries(https_client PRIVATE
-    wintls
-  )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      target_compile_options(${name} PRIVATE -Wno-unused-private-field)
+    endif()
 
-  target_link_libraries(async_https_client PRIVATE
-    wintls
-  )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      # Work around string table overflow by enabling optimizations
+      target_compile_options(${name} PRIVATE -Os)
+      # Work around null pointer deref warning in boost code from GCC 12
+      target_compile_options(${name} PRIVATE -fno-delete-null-pointer-checks)
+    endif()
+  endfunction()
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # Temporary workaround issue https://github.com/boostorg/beast/issues/1582
-    target_compile_options(https_client PRIVATE "-wd4702")
-    target_compile_options(async_https_client PRIVATE "-wd4702")
-  endif()
-
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(https_client PRIVATE -Wno-unused-private-field)
-    target_compile_options(async_https_client PRIVATE -Wno-unused-private-field)
-  endif()
-
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # Work around string table overflow by enabling optimizations
-    target_compile_options(async_https_client PRIVATE -Os)
-    # Work around null pointer deref warning in boost code from GCC 12
-    target_compile_options(async_https_client PRIVATE -fno-delete-null-pointer-checks)
-  endif()
+  add_wintls_example(https_client)
+  add_wintls_example(async_https_client)
 endif()

--- a/examples/async_websocket_client.cpp
+++ b/examples/async_websocket_client.cpp
@@ -1,0 +1,180 @@
+//
+// Copyright (c) 2024 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/asio/strand.hpp>
+
+#include <wintls.hpp>
+#include <wintls/beast.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace beast = boost::beast;         // from <boost/beast.hpp>
+namespace websocket = beast::websocket; // from <boost/beast/websocket.hpp>
+namespace net = boost::asio;            // from <boost/asio.hpp>
+namespace ssl = wintls;                 // from <wintls/wintls.hpp>
+using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
+
+//------------------------------------------------------------------------------
+
+// Report a failure
+void fail(beast::error_code ec, const char* what) {
+  std::cerr << what << ": " << ec.message() << "\n";
+}
+
+// Sends a WebSocket message and prints the response
+class session : public std::enable_shared_from_this<session> {
+  tcp::resolver resolver_;
+  websocket::stream<ssl::stream<beast::tcp_stream>> ws_;
+  beast::flat_buffer buffer_;
+  std::string host_;
+  std::string text_;
+
+public:
+  // Resolver and socket require an io_context
+  explicit session(net::io_context& ioc, ssl::context& ctx)
+      : resolver_(net::make_strand(ioc))
+      , ws_(net::make_strand(ioc), ctx) {
+  }
+
+  // Start the asynchronous operation
+  void run(const char* host, const char* port, const char* text) {
+    // Set SNI hostname (many hosts need this to handshake successfully)
+    ws_.next_layer().set_server_hostname(host);
+
+    // Enable Check whether the Server Certificate was revoked
+    ws_.next_layer().set_certificate_revocation_check(true);
+
+    // Save these for later
+    host_ = host;
+    text_ = text;
+
+    // Look up the domain name
+    resolver_.async_resolve(host, port, beast::bind_front_handler(&session::on_resolve, shared_from_this()));
+  }
+
+  void on_resolve(beast::error_code ec, tcp::resolver::results_type results) {
+    if (ec)
+      return fail(ec, "resolve");
+
+    // Set a timeout on the operation
+    beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
+
+    // Make the connection on the IP address we get from a lookup
+    beast::get_lowest_layer(ws_).async_connect(results,
+                                               beast::bind_front_handler(&session::on_connect, shared_from_this()));
+  }
+
+  void on_connect(beast::error_code ec, tcp::resolver::results_type::endpoint_type ep) {
+    if (ec)
+      return fail(ec, "connect");
+
+    // Set a timeout on the operation
+    beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
+
+    // Update the host_ string. This will provide the value of the
+    // Host HTTP header during the WebSocket handshake.
+    // See https://tools.ietf.org/html/rfc7230#section-5.4
+    host_ += ':' + std::to_string(ep.port());
+
+    // Perform the SSL handshake
+    ws_.next_layer().async_handshake(wintls::handshake_type::client,
+                                     beast::bind_front_handler(&session::on_ssl_handshake, shared_from_this()));
+  }
+
+  void on_ssl_handshake(beast::error_code ec) {
+    if (ec)
+      return fail(ec, "ssl_handshake");
+
+    // Turn off the timeout on the tcp_stream, because
+    // the websocket stream has its own timeout system.
+    beast::get_lowest_layer(ws_).expires_never();
+
+    // Set suggested timeout settings for the websocket
+    ws_.set_option(websocket::stream_base::timeout::suggested(beast::role_type::client));
+
+    // Perform the websocket handshake
+    ws_.async_handshake(host_, "/", beast::bind_front_handler(&session::on_handshake, shared_from_this()));
+  }
+
+  void on_handshake(beast::error_code ec) {
+    if (ec)
+      return fail(ec, "handshake");
+
+    // Send the message
+    ws_.async_write(net::buffer(text_), beast::bind_front_handler(&session::on_write, shared_from_this()));
+  }
+
+  void on_write(beast::error_code ec, std::size_t bytes_transferred) {
+    boost::ignore_unused(bytes_transferred);
+
+    if (ec)
+      return fail(ec, "write");
+
+    // Read a message into our buffer
+    ws_.async_read(buffer_, beast::bind_front_handler(&session::on_read, shared_from_this()));
+  }
+
+  void on_read(beast::error_code ec, std::size_t bytes_transferred) {
+    boost::ignore_unused(bytes_transferred);
+
+    if (ec)
+      return fail(ec, "read");
+
+    // Close the WebSocket connection
+    ws_.async_close(websocket::close_code::normal, beast::bind_front_handler(&session::on_close, shared_from_this()));
+  }
+
+  void on_close(beast::error_code ec) {
+    if (ec)
+      return fail(ec, "close");
+
+    // If we get here then the connection is closed gracefully
+
+    // The make_printable() function helps print a ConstBufferSequence
+    std::cout << beast::make_printable(buffer_.data()) << std::endl;
+  }
+};
+
+//------------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+  // Check command line arguments.
+  if (argc != 4) {
+    std::cerr << "Usage: " << argv[0] << " <host> <port> <text>\n\n"
+              << "Example: " << argv[0] << " echo.websocket.org 443 \"Hello, world!\"\n";
+    return EXIT_FAILURE;
+  }
+  const auto host = argv[1];
+  const auto port = argv[2];
+  const auto text = argv[3];
+
+  // The io_context is required for all I/O
+  net::io_context ioc;
+
+  // The SSL context is required, and holds certificates
+  ssl::context ctx{wintls::method::system_default};
+
+  // Use the operating systems default certificates for verification
+  ctx.use_default_certificates(true);
+
+  // Verify the remote server's certificate
+  ctx.verify_server_certificate(true);
+
+  // Launch the asynchronous operation
+  std::make_shared<session>(ioc, ctx)->run(host, port, text);
+
+  // Run the I/O service. The call will return when
+  // the socket is closed.
+  ioc.run();
+
+  return EXIT_SUCCESS;
+}

--- a/examples/websocket_client.cpp
+++ b/examples/websocket_client.cpp
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2024 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+#include <wintls.hpp>
+#include <wintls/beast.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace beast = boost::beast;         // from <boost/beast.hpp>
+namespace websocket = beast::websocket; // from <boost/beast/websocket.hpp>
+namespace net = boost::asio;            // from <boost/asio.hpp>
+namespace ssl = wintls;                 // from <wintls/wintls.hpp>
+using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
+
+//------------------------------------------------------------------------------
+
+// Sends a WebSocket message and prints the response
+int main(int argc, char** argv) {
+  try {
+    // Check command line arguments.
+    if (argc != 4) {
+      std::cerr << "Usage: " << argv[0] << " <host> <port> <text>\n\n";
+      std::cerr << "Example: " << argv[0] << " echo.websocket.org 443 \"Hello, world!\"\n";
+      return EXIT_FAILURE;
+    }
+    std::string host = argv[1];
+    const auto port = argv[2];
+    const auto text = argv[3];
+
+    // The io_context is required for all I/O
+    net::io_context ioc;
+
+    // The SSL context is required, and holds certificates
+    ssl::context ctx{wintls::method::system_default};
+
+    // Use the operating systems default certificates for verification
+    ctx.use_default_certificates(true);
+
+    // Verify the remote server's certificate
+    ctx.verify_server_certificate(true);
+
+    // Construct the TLS stream with the parameters from the context
+    // These objects perform our I/O
+    tcp::resolver resolver{ioc};
+    websocket::stream<ssl::stream<tcp::socket>> ws{ioc, ctx};
+
+    // Set SNI hostname (many hosts need this to handshake successfully)
+    ws.next_layer().set_server_hostname(host);
+
+    // Enable Check whether the Server Certificate was revoked
+    ws.next_layer().set_certificate_revocation_check(true);
+
+    // Look up the domain name
+    const auto results = resolver.resolve(host, port);
+
+    // Make the connection on the IP address we get from a lookup
+    auto ep = net::connect(beast::get_lowest_layer(ws), results);
+
+    // Set SNI Hostname (many hosts need this to handshake successfully)
+    ws.next_layer().set_server_hostname(host.c_str());
+
+    // Update the host_ string. This will provide the value of the
+    // Host HTTP header during the WebSocket handshake.
+    // See https://tools.ietf.org/html/rfc7230#section-5.4
+    host += ':' + std::to_string(ep.port());
+
+    // Perform the SSL handshake
+    ws.next_layer().handshake(wintls::handshake_type::client);
+
+    // Perform the websocket handshake
+    ws.handshake(host, "/");
+
+    // Send the message
+    ws.write(net::buffer(std::string(text)));
+
+    // This buffer will hold the incoming message
+    beast::flat_buffer buffer;
+
+    // Read a message into our buffer
+    ws.read(buffer);
+
+    // Close the WebSocket connection
+    ws.close(websocket::close_code::normal);
+
+    // If we get here then the connection is closed gracefully
+
+    std::cout << beast::make_printable(buffer.data()) << std::endl;
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/include/wintls/beast.hpp
+++ b/include/wintls/beast.hpp
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2024 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_BEAST_HPP
+#define BOOST_WINTLS_BEAST_HPP
+
+#include <boost/version.hpp>
+#include <boost/beast/websocket.hpp>
+#include <wintls/context.hpp>
+#include <wintls/stream.hpp>
+
+namespace boost {
+namespace beast {
+
+namespace detail {
+
+template<class AsyncStream>
+struct wintls_shutdown_op : boost::asio::coroutine {
+  wintls_shutdown_op(wintls::stream<AsyncStream>& s, role_type role)
+      : s_(s)
+      , role_(role) {
+  }
+
+  template<class Self>
+  void operator()(Self& self, error_code ec = {}, std::size_t = 0) {
+    BOOST_ASIO_CORO_REENTER(*this) {
+#if (BOOST_VERSION / 100 % 1000) >= 77
+      self.reset_cancellation_state(net::enable_total_cancellation());
+#endif
+
+      BOOST_ASIO_CORO_YIELD
+      s_.async_shutdown(std::move(self));
+      ec_ = ec;
+
+      using boost::beast::websocket::async_teardown;
+      BOOST_ASIO_CORO_YIELD
+      async_teardown(role_, s_.next_layer(), std::move(self));
+      if (!ec_) {
+        ec_ = ec;
+      }
+
+      self.complete(ec_);
+    }
+  }
+
+private:
+  wintls::stream<AsyncStream>& s_;
+  role_type role_;
+  error_code ec_;
+};
+
+} // namespace detail
+
+template<class AsyncStream, class TeardownHandler>
+void async_teardown(role_type role, wintls::stream<AsyncStream>& stream, TeardownHandler&& handler) {
+  return boost::asio::async_compose<TeardownHandler, void(error_code)>(
+      detail::wintls_shutdown_op<AsyncStream>(stream, role), handler, stream);
+}
+
+template<class AsyncStream>
+void teardown(boost::beast::role_type role, wintls::stream<AsyncStream>& stream, boost::system::error_code& ec) {
+  stream.shutdown(ec);
+  using boost::beast::websocket::teardown;
+  boost::system::error_code ec2;
+  teardown(role, stream.next_layer(), ec ? ec2 : ec);
+}
+
+} // namespace beast
+} // namespace boost
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,10 @@ set(test_sources
   decrypted_data_buffer_test.cpp
 )
 
+if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
+  list(APPEND test_sources echo_test_ws.cpp)
+endif()
+
 add_executable(unittest
   ${test_sources}
 )
@@ -49,6 +53,14 @@ endif()
 
 if(MSVC)
   target_compile_options(unittest PRIVATE "-bigobj")
+endif()
+
+if(MINGW)
+  target_compile_options(unittest PRIVATE "-Wa,-mbig-obj")
+  # Work around string table overflow by enabling optimizations
+  target_compile_options(unittest PRIVATE -O1)
+  # Work around null pointer deref warning in boost code from GCC 12
+  target_compile_options(unittest PRIVATE -fno-delete-null-pointer-checks)
 endif()
 
 target_compile_definitions(unittest PRIVATE
@@ -81,6 +93,18 @@ if(${CMAKE_CXX_STANDARD} LESS 17 AND ENABLE_WINTLS_STANDALONE_ASIO)
     string-view-lite
     variant-lite
   )
+endif()
+
+if(NOT ENABLE_WINTLS_STANDALONE_ASIO)
+  if(MSVC AND ${Boost_VERSION} VERSION_LESS "1.76")
+    # Unreferenced formal parameter in boost/beast/websocket/impl/ssl.hpp
+    target_compile_options(unittest PRIVATE /wd4100)
+  endif()
+
+  if(MSVC AND ${Boost_VERSION} VERSION_LESS "1.85")
+    # Unreachable code in boost/beast/core/impl/buffers_cat.hpp
+    target_compile_options(unittest PRIVATE /wd4702)
+  endif()
 endif()
 
 include(CTest)

--- a/test/async_ws_echo_client.hpp
+++ b/test/async_ws_echo_client.hpp
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2023 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_TEST_ASYNC_ECHO_CLIENT_HPP
+#define BOOST_WINTLS_TEST_ASYNC_ECHO_CLIENT_HPP
+
+#include "unittest.hpp"
+
+template<typename Stream>
+struct async_ws_echo_client : public Stream {
+public:
+  using Stream::stream;
+
+  async_ws_echo_client(net::io_context& context, const std::string& message)
+      : Stream(context)
+      , message_(message)
+      , ws_(stream) {
+  }
+
+  void run() {
+    do_tls_handshake();
+  }
+
+  std::string received_message() const {
+    return std::string(net::buffers_begin(recv_buffer_.data()),
+                       net::buffers_begin(recv_buffer_.data()) + static_cast<std::ptrdiff_t>(recv_buffer_.size()));
+  }
+
+private:
+  void do_tls_handshake() {
+    ws_.next_layer().async_handshake(Stream::handshake_type::client, [this](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+      do_ws_handshake();
+    });
+  }
+
+  void do_ws_handshake() {
+    ws_.async_handshake("localhost", "/", [this](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+      do_write();
+    });
+  }
+
+  void do_write() {
+    ws_.async_write(net::buffer(message_), [this](const boost::system::error_code& ec, std::size_t) {
+      REQUIRE_FALSE(ec);
+      do_read();
+    });
+  }
+
+  void do_read() {
+    ws_.async_read(recv_buffer_, [this](const boost::system::error_code& ec, std::size_t) {
+      REQUIRE_FALSE(ec);
+      do_shutdown();
+    });
+  }
+
+  void do_shutdown() {
+    ws_.async_close(websocket::close_code::normal, [](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+    });
+  }
+
+  std::string message_;
+  beast::flat_buffer recv_buffer_;
+  websocket::stream<decltype(stream)&> ws_;
+};
+
+#endif // BOOST_WINTLS_TEST_ASYNC_ECHO_CLIENT_HPP

--- a/test/async_ws_echo_server.hpp
+++ b/test/async_ws_echo_server.hpp
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2023 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_TEST_ASYNC_ECHO_SERVER_HPP
+#define BOOST_WINTLS_TEST_ASYNC_ECHO_SERVER_HPP
+
+#include "unittest.hpp"
+
+template<typename Stream>
+class async_ws_echo_server : public Stream {
+public:
+  using Stream::stream;
+
+  async_ws_echo_server(net::io_context& context)
+      : Stream(context)
+      , ws_(stream) {
+  }
+
+  void run() {
+    do_tls_handshake();
+  }
+
+private:
+  void do_tls_handshake() {
+    ws_.next_layer().async_handshake(Stream::handshake_type::server, [this](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+      do_ws_handshake();
+    });
+  }
+
+  void do_ws_handshake() {
+    ws_.async_accept([this](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+      do_read();
+    });
+  }
+
+  void do_read() {
+    ws_.async_read(recv_buffer_, [this](const boost::system::error_code& ec, std::size_t) {
+      REQUIRE_FALSE(ec);
+      ws_.text(ws_.got_text());
+      do_write();
+    });
+  }
+
+  void do_write() {
+    ws_.async_write(recv_buffer_.data(), [this](const boost::system::error_code& ec, std::size_t) {
+      REQUIRE_FALSE(ec);
+      do_shutdown();
+    });
+  }
+
+  void do_shutdown() {
+    ws_.async_close(websocket::close_code::normal, [](const boost::system::error_code& ec) {
+      REQUIRE_FALSE(ec);
+    });
+  }
+
+  beast::flat_buffer recv_buffer_;
+  websocket::stream<decltype(stream)&> ws_;
+};
+
+#endif // BOOST_WINTLS_TEST_ASYNC_ECHO_SERVER_HPP

--- a/test/echo_test_ws.cpp
+++ b/test/echo_test_ws.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2020 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "ws_echo_server.hpp"
+#include "ws_echo_client.hpp"
+#include "async_ws_echo_server.hpp"
+#include "async_ws_echo_client.hpp"
+#include "asio_ssl_client_stream.hpp"
+#include "asio_ssl_server_stream.hpp"
+#include "wintls_client_stream.hpp"
+#include "wintls_server_stream.hpp"
+#include "unittest.hpp"
+
+#include <wintls.hpp>
+
+#include <string>
+#include <tuple>
+
+namespace {
+std::string generate_data(std::size_t size) {
+  std::string ret(size, '\0');
+  for (std::size_t i = 0; i < size - 1; ++i) {
+    ret[i] = static_cast<char>(i % 26 + 65);
+  }
+  return ret;
+}
+
+} // namespace
+
+using TestTypes = std::tuple<std::tuple<asio_ssl_client_stream, asio_ssl_server_stream>,
+                             std::tuple<wintls_client_stream, asio_ssl_server_stream>,
+                             std::tuple<asio_ssl_client_stream, wintls_server_stream>,
+                             std::tuple<wintls_client_stream, wintls_server_stream>>;
+
+TEMPLATE_LIST_TEST_CASE("echo test ws", "", TestTypes) {
+  using ClientStream = typename std::tuple_element<0, TestType>::type;
+  using ServerStream = typename std::tuple_element<1, TestType>::type;
+
+  auto test_data_size = GENERATE(0x100,
+                                 0x100 - 1,
+                                 0x100 + 1,
+                                 0x1000,
+                                 0x1000 - 1,
+                                 0x1000 + 1,
+                                 0x10000,
+                                 0x10000 - 1,
+                                 0x10000 + 1,
+                                 0x100000,
+                                 0x100000 - 1,
+                                 0x100000 + 1);
+  const std::string test_data = generate_data(static_cast<std::size_t>(test_data_size));
+
+  net::io_context io_context;
+
+  SECTION("sync test") {
+    ws_echo_client<ClientStream> client(io_context);
+    ws_echo_server<ServerStream> server(io_context);
+
+    client.stream.next_layer().connect(server.stream.next_layer());
+
+    auto handshake_result = server.handshake();
+    client.handshake();
+    REQUIRE_FALSE(handshake_result.get());
+
+    client.write(test_data);
+    server.read();
+    server.write();
+    client.read();
+
+    auto shutdown_result = server.shutdown();
+    client.shutdown();
+    REQUIRE_FALSE(shutdown_result.get());
+
+    CHECK(client.template data<std::string>() == test_data);
+  }
+
+  SECTION("async test") {
+    async_ws_echo_server<ServerStream> server(io_context);
+    async_ws_echo_client<ClientStream> client(io_context, test_data);
+    client.stream.next_layer().connect(server.stream.next_layer());
+    server.run();
+    client.run();
+    io_context.run();
+    CHECK(client.received_message() == test_data);
+  }
+}

--- a/test/test_stream/impl/is_invocable.hpp
+++ b/test/test_stream/impl/is_invocable.hpp
@@ -16,9 +16,10 @@
 namespace wintls {
 namespace test {
 
+// Note: This is prefixed to avoid conflicts with boost::beast::detail::is_invocable_test
 template<class R, class C, class ...A>
 auto
-is_invocable_test(C&& c, int, A&& ...a)
+wintls_is_invocable_test(C&& c, int, A&& ...a)
     -> decltype(std::is_convertible<
         decltype(c(std::forward<A>(a)...)), R>::value ||
             std::is_same<R, void>::value,
@@ -26,7 +27,7 @@ is_invocable_test(C&& c, int, A&& ...a)
 
 template<class R, class C, class ...A>
 std::false_type
-is_invocable_test(C&& c, long, A&& ...a);
+wintls_is_invocable_test(C&& c, long, A&& ...a);
 
 /** Metafunction returns `true` if F callable as R(A...)
 
@@ -44,7 +45,7 @@ struct is_invocable : std::false_type
 
 template<class C, class R, class ...A>
 struct is_invocable<C, R(A...)>
-    : decltype(is_invocable_test<R>(
+    : decltype(wintls_is_invocable_test<R>(
         std::declval<C>(), 1, std::declval<A>()...))
 {
 };

--- a/test/test_stream/role.hpp
+++ b/test/test_stream/role.hpp
@@ -13,6 +13,7 @@
 namespace wintls {
 namespace test {
 
+#ifdef WINTLS_USE_STANDALONE_ASIO
 /** The role of local or remote peer.
 
     Whether the endpoint is a client or server affects the
@@ -41,6 +42,11 @@ enum class role_type
     /// The stream is operating as a server.
     server
 };
+#else // WINTLS_USE_STANDALONE_ASIO
+#include <boost/beast/core.hpp>
+
+using role_type = boost::beast::role_type;
+#endif // !WINTLS_USE_STANDALONE_ASIO
 
 } // namespace test
 } // namespace wintls

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -9,12 +9,18 @@
 
 #include <wintls/detail/config.hpp>
 
+#ifndef WINTLS_USE_STANDALONE_ASIO
+#include <boost/beast/core.hpp>
+#endif // !WINTLS_USE_STANDALONE_ASIO
+
 #include "test_stream/stream.hpp"
 
 #ifdef WINTLS_USE_STANDALONE_ASIO
 #include <asio/ssl.hpp>
 #else // WINTLS_USE_STANDALONE_ASIO
+#include <boost/beast/websocket/ssl.hpp>
 #include <boost/asio/ssl.hpp>
+#include <wintls/beast.hpp>
 #endif // !WINTLS_USE_STANDALONE_ASIO
 
 #include <catch2/catch.hpp>
@@ -33,7 +39,7 @@ struct StringMaker<error_code> {
     return oss.str();
   }
 };
-}
+} // namespace Catch
 
 inline std::vector<unsigned char> bytes_from_file(const std::string& path) {
   std::ifstream ifs{path};
@@ -46,8 +52,10 @@ inline std::vector<unsigned char> bytes_from_file(const std::string& path) {
 namespace net = wintls::net;
 #ifdef WINTLS_USE_STANDALONE_ASIO
 namespace asio_ssl = asio::ssl;
-#else // WINTLS_USE_STANDALONE_ASIO
+#else  // WINTLS_USE_STANDALONE_ASIO
 namespace asio_ssl = boost::asio::ssl;
+namespace beast = boost::beast;
+namespace websocket = boost::beast::websocket;
 #endif // !WINTLS_USE_STANDALONE_ASIO
 using test_stream = wintls::test::stream;
 

--- a/test/ws_echo_client.hpp
+++ b/test/ws_echo_client.hpp
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2023 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_TEST_ECHO_CLIENT_HPP
+#define BOOST_WINTLS_TEST_ECHO_CLIENT_HPP
+
+#include "unittest.hpp"
+
+template<typename Stream>
+class ws_echo_client : public Stream {
+public:
+  using Stream::stream;
+
+  ws_echo_client(net::io_context& context)
+      : Stream(context)
+      , ws_(stream) {
+  }
+
+  void handshake() {
+    ws_.next_layer().handshake(Stream::handshake_type::client);
+    ws_.handshake("localhost", "/");
+  }
+
+  void shutdown() {
+    ws_.close(websocket::close_code::normal);
+  }
+
+  void read() {
+    ws_.read(buffer_);
+    ws_.text(ws_.got_text());
+  }
+
+  template<typename T>
+  void write(const T& data) {
+    ws_.write(net::buffer(data));
+  }
+
+  template<typename T>
+  T data() const {
+    return T(net::buffers_begin(buffer_.data()),
+             net::buffers_begin(buffer_.data()) + static_cast<std::ptrdiff_t>(buffer_.size()));
+  }
+
+private:
+  beast::flat_buffer buffer_;
+  websocket::stream<decltype(stream)&> ws_;
+};
+
+#endif // BOOST_WINTLS_TEST_ECHO_CLIENT_HPP

--- a/test/ws_echo_server.hpp
+++ b/test/ws_echo_server.hpp
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2023 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINTLS_TEST_ECHO_SERVER_HPP
+#define BOOST_WINTLS_TEST_ECHO_SERVER_HPP
+
+#include "unittest.hpp"
+
+#include <future>
+
+template<typename Stream>
+class ws_echo_server : public Stream {
+public:
+  using Stream::stream;
+
+  ws_echo_server(net::io_context& context)
+      : Stream(context)
+      , ws_(stream) {
+  }
+
+  std::future<boost::system::error_code> handshake() {
+    return std::async(std::launch::async, [this]() {
+      boost::system::error_code ec{};
+      ws_.next_layer().handshake(Stream::handshake_type::server, ec);
+      ws_.accept(ec);
+      return ec;
+    });
+  }
+
+  std::future<boost::system::error_code> shutdown() {
+    return std::async(std::launch::async, [this]() {
+      boost::system::error_code ec{};
+      ws_.close(websocket::close_code::normal, ec);
+      return ec;
+    });
+  }
+
+  void read() {
+    ws_.read(buffer_);
+    ws_.text(ws_.got_text());
+  }
+
+  void write() {
+    ws_.write(buffer_.data());
+  }
+
+private:
+  beast::flat_buffer buffer_;
+  websocket::stream<decltype(stream)&> ws_;
+};
+
+#endif // BOOST_WINTLS_TEST_ECHO_SERVER_HPP


### PR DESCRIPTION
I ran into https://github.com/laudrup/boost-wintls/issues/22, and having to add the termination code isn't ideal, so I added the code here. Since I'm not sure if _all_ Boost installations (that have at least ASIO) will have beast, I added a check if beast is available and didn't include it in the `beast/wintls.hpp` wrapper (is that assumption true?).

I added tests for sync and async WebSocket servers to the echo test-case.