### PR TITLE
Use ANSI functions explicitly

### DIFF
--- a/include/wintls/detail/encrypt_buffers.hpp
+++ b/include/wintls/detail/encrypt_buffers.hpp
@@ -29,7 +29,7 @@ public:
 
   template <typename ConstBufferSequence> std::size_t operator()(const ConstBufferSequence& buffers, SECURITY_STATUS& sc) {
     if (data_.empty()) {
-      sc = sspi_functions::QueryContextAttributes(ctxt_handle_.get(), SECPKG_ATTR_STREAM_SIZES, &stream_sizes_);
+      sc = sspi_functions::QueryContextAttributesA(ctxt_handle_.get(), SECPKG_ATTR_STREAM_SIZES, &stream_sizes_);
       if (sc != SEC_E_OK) {
         return 0;
       }

--- a/include/wintls/detail/sspi_functions.hpp
+++ b/include/wintls/detail/sspi_functions.hpp
@@ -15,14 +15,14 @@ namespace wintls {
 namespace detail {
 namespace sspi_functions {
 
-inline SecurityFunctionTable* sspi_function_table() {
-  static SecurityFunctionTable* impl = InitSecurityInterface();
+inline SecurityFunctionTableA* sspi_function_table() {
+  static SecurityFunctionTableA* impl = InitSecurityInterfaceA();
   // TODO: Figure out some way to signal this to the user instead of aborting
   WINTLS_ASSERT_MSG(impl != nullptr, "Unable to initialize SecurityFunctionTable");
   return impl;
 }
 
-inline SECURITY_STATUS AcquireCredentialsHandle(SEC_CHAR* pPrincipal,
+inline SECURITY_STATUS AcquireCredentialsHandleA(SEC_CHAR* pPrincipal,
                                                 SEC_CHAR* pPackage,
                                                 unsigned long fCredentialUse,
                                                 void* pvLogonId,
@@ -31,7 +31,7 @@ inline SECURITY_STATUS AcquireCredentialsHandle(SEC_CHAR* pPrincipal,
                                                 void* pvGetKeyArgument,
                                                 PCredHandle phCredential,
                                                 PTimeStamp ptsExpiry) {
-  return sspi_function_table()->AcquireCredentialsHandle(pPrincipal,
+  return sspi_function_table()->AcquireCredentialsHandleA(pPrincipal,
                                                           pPackage,
                                                           fCredentialUse,
                                                           pvLogonId,
@@ -46,7 +46,7 @@ inline SECURITY_STATUS DeleteSecurityContext(PCtxtHandle phContext) {
   return sspi_function_table()->DeleteSecurityContext(phContext);
 }
 
-inline SECURITY_STATUS InitializeSecurityContext(PCredHandle phCredential,
+inline SECURITY_STATUS InitializeSecurityContextA(PCredHandle phCredential,
                                                  PCtxtHandle phContext,
                                                  SEC_CHAR* pTargetName,
                                                  unsigned long fContextReq,
@@ -58,7 +58,7 @@ inline SECURITY_STATUS InitializeSecurityContext(PCredHandle phCredential,
                                                  PSecBufferDesc pOutput,
                                                  unsigned long* pfContextAttr,
                                                  PTimeStamp ptsExpiry) {
-  return sspi_function_table()->InitializeSecurityContext(phCredential,
+  return sspi_function_table()->InitializeSecurityContextA(phCredential,
                                                            phContext,
                                                            pTargetName,
                                                            fContextReq,
@@ -80,8 +80,8 @@ inline SECURITY_STATUS DecryptMessage(PCtxtHandle phContext, PSecBufferDesc pMes
   return sspi_function_table()->DecryptMessage(phContext, pMessage, MessageSeqNo, pfQOP);
 }
 
-inline SECURITY_STATUS QueryContextAttributes(PCtxtHandle phContext, unsigned long ulAttribute, void* pBuffer) {
-  return sspi_function_table()->QueryContextAttributes(phContext, ulAttribute, pBuffer);
+inline SECURITY_STATUS QueryContextAttributesA(PCtxtHandle phContext, unsigned long ulAttribute, void* pBuffer) {
+  return sspi_function_table()->QueryContextAttributesA(phContext, ulAttribute, pBuffer);
 }
 
 inline SECURITY_STATUS EncryptMessage(PCtxtHandle phContext, unsigned long fQOP, PSecBufferDesc pMessage, unsigned long MessageSeqNo) {

--- a/include/wintls/detail/sspi_handshake.hpp
+++ b/include/wintls/detail/sspi_handshake.hpp
@@ -88,7 +88,7 @@ public:
     }
 
     TimeStamp expiry;
-    last_error_ = detail::sspi_functions::AcquireCredentialsHandle(nullptr,
+    last_error_ = detail::sspi_functions::AcquireCredentialsHandleA(nullptr,
                                                                    const_cast<SEC_CHAR*>(UNISP_NAME),
                                                                    static_cast<unsigned>(usage),
                                                                    nullptr,
@@ -106,7 +106,7 @@ public:
         DWORD out_flags = 0;
 
         handshake_output_buffers buffers;
-        last_error_ = detail::sspi_functions::InitializeSecurityContext(cred_handle_.get(),
+        last_error_ = detail::sspi_functions::InitializeSecurityContextA(cred_handle_.get(),
                                                                         nullptr,
                                                                         const_cast<SEC_CHAR*>(server_hostname_.c_str()),
                                                                         client_context_flags,
@@ -148,7 +148,7 @@ public:
 
     switch(handshake_type_) {
       case handshake_type::client:
-        last_error_ = detail::sspi_functions::InitializeSecurityContext(cred_handle_.get(),
+        last_error_ = detail::sspi_functions::InitializeSecurityContextA(cred_handle_.get(),
                                                                         ctxt_handle_.get(),
                                                                         const_cast<SEC_CHAR*>(server_hostname_.c_str()),
                                                                         client_context_flags,
@@ -281,7 +281,7 @@ private:
       return SEC_E_OK;
     }
     const CERT_CONTEXT* ctx_ptr = nullptr;
-    last_error_ = detail::sspi_functions::QueryContextAttributes(ctxt_handle_.get(), SECPKG_ATTR_REMOTE_CERT_CONTEXT, &ctx_ptr);
+    last_error_ = detail::sspi_functions::QueryContextAttributesA(ctxt_handle_.get(), SECPKG_ATTR_REMOTE_CERT_CONTEXT, &ctx_ptr);
     if (last_error_ != SEC_E_OK) {
       return last_error_;
     }

--- a/include/wintls/detail/sspi_shutdown.hpp
+++ b/include/wintls/detail/sspi_shutdown.hpp
@@ -36,7 +36,7 @@ public:
     }
 
     DWORD out_flags = 0;
-    sc = detail::sspi_functions::InitializeSecurityContext(cred_handle_.get(),
+    sc = detail::sspi_functions::InitializeSecurityContextA(cred_handle_.get(),
                                                            ctxt_handle_.get(),
                                                            nullptr,
                                                            client_context_flags,


### PR DESCRIPTION
A simple attempt at fixing the issues with UNICODE. I've not removed the countermeasures already implemented.

Work towards: https://github.com/laudrup/boost-wintls/issues/84