### PR TITLE
Move manual_auth out of the handshake loop.

### DIFF
--- a/include/wintls/detail/async_handshake.hpp
+++ b/include/wintls/detail/async_handshake.hpp
@@ -81,29 +81,6 @@ struct async_handshake : net::coroutine {
           self.complete(handshake_.last_error());
           return;
         }
-
-        if (handshake_state == detail::sspi_handshake::state::done_with_data) {
-          WINTLS_ASIO_CORO_YIELD {
-            state_ = state::writing;
-            net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
-          }
-          break;
-        }
-
-        if (handshake_state == detail::sspi_handshake::state::error_with_data) {
-          WINTLS_ASIO_CORO_YIELD {
-            state_ = state::writing;
-            net::async_write(next_layer_, handshake_.out_buffer(), std::move(self));
-          }
-          if (!is_continuation()) {
-            WINTLS_ASIO_CORO_YIELD {
-              auto e = self.get_executor();
-              net::post(e, [self = std::move(self), ec, length]() mutable { self(ec, length); });
-            }
-          }
-          self.complete(handshake_.last_error());
-          return;
-        }
       }
 
       if (!is_continuation()) {
@@ -113,6 +90,7 @@ struct async_handshake : net::coroutine {
         }
       }
       assert(!handshake_.last_error());
+      handshake_.manual_auth();
       self.complete(handshake_.last_error());
     }
   }


### PR DESCRIPTION
Cherry picked from #77.
This was the first proper change from that PR.
I will wait for this to be reviewed and hopefully merged before getting the other changes from that PR up to date.

Short explanation: There was some redundancy in the handling of `sspi_handshake::state::done` and `sspi_handshake::state::done_with_data` and the corresponding `error` values.
This changes the code such that the manual auth is only called after `sspi_handshake::state::done` was produced, removing the need for the two `*_with_data` values.