### PR TITLE
Enable TPM-backed key support for client authentication via boost-wintls

### DIFF
--- a/include/wintls/detail/context_certificates.hpp
+++ b/include/wintls/detail/context_certificates.hpp
@@ -87,7 +87,7 @@ public:
     DWORD unused_1;
     BOOL unused_2;
     if (!CryptAcquireCertificatePrivateKey(cert,
-                                           CRYPT_ACQUIRE_COMPARE_KEY_FLAG,
+                                           CRYPT_ACQUIRE_COMPARE_KEY_FLAG | CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG,
                                            nullptr,
                                            &unused_0,
                                            &unused_1,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(unittest PRIVATE
   OpenSSL::Crypto
   Threads::Threads
   Catch2::Catch2
+  ncrypt
   wintls
 )
 

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -140,7 +140,9 @@ wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::
                                                         MS_PLATFORM_KEY_STORAGE_PROVIDER,
                                                         0);
   if (providerOpened != ERROR_SUCCESS) {
-    wintls::detail::throw_last_error("NCryptOpenStorageProvider");
+    wintls::detail::throw_last_error((
+      "NCryptOpenStorageProvider("
+      + std::to_string(providerOpened)+ "," + std::to_string(ERROR_SUCCESS) + ")").c_str());
   }
 
   NCRYPT_KEY_HANDLE hKey{};
@@ -252,7 +254,7 @@ TEST_CASE("certificates") {
     auto cert = x509_to_cert_context(net::buffer(test_certificate), wintls::file_format::pem);
 
     CHECK_THROWS_WITH(server_ctx.use_certificate(cert.get()),
-    Catch::Matchers::Contains("Cannot find the certificate and private key for decryption"));
+                      Catch::Matchers::Contains("Cannot find the certificate and private key for decryption"));
 
     error_code ec{};
     server_ctx.use_certificate(cert.get(), ec);

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -134,6 +134,18 @@ wintls::cert_context_ptr create_self_signed_cert(const std::string& subject) {
   return wintls::cert_context_ptr{cert};
 }
 
+bool able_to_test_tpm_backed_key() {
+  NCRYPT_PROV_HANDLE hProvider{};
+  const auto providerOpened = NCryptOpenStorageProvider(&hProvider,
+                                                        MS_PLATFORM_KEY_STORAGE_PROVIDER,
+                                                        0);
+  if (providerOpened != ERROR_SUCCESS) {
+    return false;
+  }
+  NCryptFreeObject(hProvider);
+  return true;
+}
+
 wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::string& subject) {
   NCRYPT_PROV_HANDLE hProvider{};
   const auto providerOpened = NCryptOpenStorageProvider(&hProvider,
@@ -141,8 +153,7 @@ wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::
                                                         0);
   if (providerOpened != ERROR_SUCCESS) {
     wintls::detail::throw_last_error((
-      "NCryptOpenStorageProvider("
-      + std::to_string(providerOpened)+ "," + std::to_string(ERROR_SUCCESS) + ")").c_str());
+      "NCryptOpenStorageProvider(" + std::to_string(providerOpened) + ")").c_str());
   }
 
   NCRYPT_KEY_HANDLE hKey{};
@@ -263,6 +274,9 @@ TEST_CASE("certificates") {
   }
 
   SECTION("server cert with TPM-backed private key") {
+    if (!able_to_test_tpm_backed_key()) {
+      return;
+    }
     wintls::context server_ctx(wintls::method::system_default);
     auto cert = create_self_signed_cert_with_tpm_backed_key("CN=WinTLS, T=Test");
     error_code ec{};

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -135,20 +135,20 @@ wintls::cert_context_ptr create_self_signed_cert(const std::string& subject) {
 }
 
 bool able_to_test_tpm_backed_key() {
-  NCRYPT_PROV_HANDLE hProvider{};
-  const auto providerOpened = NCryptOpenStorageProvider(&hProvider,
+  NCRYPT_PROV_HANDLE provider{};
+  const auto providerOpened = NCryptOpenStorageProvider(&provider,
                                                         MS_PLATFORM_KEY_STORAGE_PROVIDER,
                                                         0);
   if (providerOpened != ERROR_SUCCESS) {
     return false;
   }
-  NCryptFreeObject(hProvider);
+  NCryptFreeObject(provider);
   return true;
 }
 
 wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::string& subject) {
-  NCRYPT_PROV_HANDLE hProvider{};
-  const auto providerOpened = NCryptOpenStorageProvider(&hProvider,
+  NCRYPT_PROV_HANDLE provider{};
+  const auto providerOpened = NCryptOpenStorageProvider(&provider,
                                                         MS_PLATFORM_KEY_STORAGE_PROVIDER,
                                                         0);
   if (providerOpened != ERROR_SUCCESS) {
@@ -156,21 +156,21 @@ wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::
       "NCryptOpenStorageProvider(" + std::to_string(providerOpened) + ")").c_str());
   }
 
-  NCRYPT_KEY_HANDLE hKey{};
+  NCRYPT_KEY_HANDLE key{};
   LPCWSTR keyName = L"UnitTestTPMKey";
-  const auto keyCreated = NCryptCreatePersistedKey(hProvider,
-                                                   &hKey,
+  const auto keyCreated = NCryptCreatePersistedKey(provider,
+                                                   &key,
                                                    BCRYPT_RSA_ALGORITHM,
                                                    keyName,
                                                    0,
                                                    NCRYPT_OVERWRITE_KEY_FLAG);
-  NCryptFreeObject(hProvider);
+  NCryptFreeObject(provider);
   if (keyCreated != ERROR_SUCCESS) {
     wintls::detail::throw_last_error("NCryptCreatePersistedKey");
   }
 
-  const auto keyFinalized = NCryptFinalizeKey(hKey, 0);
-  NCryptFreeObject(hKey);
+  const auto keyFinalized = NCryptFinalizeKey(key, 0);
+  NCryptFreeObject(key);
   if (keyFinalized != ERROR_SUCCESS) {
     wintls::detail::throw_last_error("NCryptFinalizeKey");
   }
@@ -189,14 +189,14 @@ wintls::cert_context_ptr create_self_signed_cert_with_tpm_backed_key(const std::
   GetSystemTime(&expiry_date);
   expiry_date.wYear += 1;
 
-  auto cert = CertCreateSelfSignCertificate(0,
-                                            &cert_subject.blob,
-                                            0,
-                                            &keyProvInfo,
-                                            nullptr,
-                                            0,
-                                            &expiry_date,
-                                            0);
+  const auto cert = CertCreateSelfSignCertificate(0,
+                                                  &cert_subject.blob,
+                                                  0,
+                                                  &keyProvInfo,
+                                                  nullptr,
+                                                  0,
+                                                  &expiry_date,
+                                                  0);
   if (!cert) {
     wintls::detail::throw_last_error("CertCreateSelfSignCertificate");
   }
@@ -278,7 +278,7 @@ TEST_CASE("certificates") {
       return;
     }
     wintls::context server_ctx(wintls::method::system_default);
-    auto cert = create_self_signed_cert_with_tpm_backed_key("CN=WinTLS, T=Test");
+    const auto cert = create_self_signed_cert_with_tpm_backed_key("CN=WinTLS, T=Test");
     error_code ec{};
     server_ctx.use_certificate(cert.get(), ec);
     CHECK(ec.value() == ERROR_SUCCESS);


### PR DESCRIPTION
This change enables the use of a TPM-backed key for client authentication. Since OpenSSL does not support TPM-backed keys without additional extensions, boost-wintls is a suitable alternative.
To make this work, I added the following line:
`CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG`
This allows acquisition of private keys managed by CNG providers, including those backed by TPM.
As I am not deeply familiar with Schannel and its edge cases, please review for any potential side effects or security implications.